### PR TITLE
Stabilize guided tour auto-scroll on iOS

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,31 +42,96 @@
 
 
       // Resolver el "root" que realmente scrollea (documento o contenedor con overflow)
+      const getDocRoot = () => document.scrollingElement || document.documentElement;
+      const isDocRoot = (node) => node === document.body || node === document.documentElement || node === getDocRoot();
+
       function resolveScrollRoot() {
         const container = document.querySelector('.container');
-        const docRoot = document.scrollingElement || document.documentElement;
-        // Usa el que tenga contenido desbordado (scrolleable)
+        const docRoot = getDocRoot();
         if (container) {
-          const cHasScroll = container.scrollHeight > container.clientHeight;
-          if (cHasScroll) return container;
+          const styles = getComputedStyle(container);
+          const canScroll = /(auto|scroll)/.test(styles.overflowY);
+          if (canScroll && container.scrollHeight - container.clientHeight > 4) {
+            return container;
+          }
         }
         return docRoot;
       }
 
       let root = resolveScrollRoot();
+      let manualTarget = isDocRoot(root) ? window : root;
+
+      const getScrollTop = () => {
+        if (isDocRoot(root)) {
+          const doc = getDocRoot();
+          return window.pageYOffset ?? doc.scrollTop ?? 0;
+        }
+        return root.scrollTop;
+      };
+
+      const setScrollTop = (value) => {
+        if (isDocRoot(root)) {
+          window.scrollTo(0, value);
+        } else {
+          root.scrollTop = value;
+        }
+      };
+
+      const getMaxScrollTop = () => {
+        if (isDocRoot(root)) {
+          const doc = getDocRoot();
+          const viewport = window.innerHeight || doc.clientHeight;
+          return Math.max(doc.scrollHeight - viewport, 0);
+        }
+        return Math.max(root.scrollHeight - root.clientHeight, 0);
+      };
 
       const SPEED = 40; // px/s — ajusta a tu gusto
       let rafId = null, lastTs = 0;
       let paused = false, ended = false, hasStarted = false;
+      let manualListenersBound = false;
+
+      const MANUAL_EVENTS = [
+        ['wheel', { passive: true }],
+        ['touchstart', { passive: true }],
+        ['mousedown', { passive: true }],
+        ['keydown', { passive: true }],
+      ];
+
+      const shouldAbortForKey = (evt) => {
+        if (evt.type !== 'keydown') return true;
+        const abortKeys = ['ArrowDown', 'ArrowUp', 'PageDown', 'PageUp', 'Home', 'End', ' '];
+        return abortKeys.includes(evt.key);
+      };
+
+      const manualAbort = (evt) => {
+        if (!rafId || ended) return;
+        if (!shouldAbortForKey(evt)) return;
+        stop();
+        paused = false;
+        ended = false;
+      };
+
+      const bindManualAbort = () => {
+        if (manualListenersBound) return;
+        manualListenersBound = true;
+        MANUAL_EVENTS.forEach(([type, opts]) => manualTarget.addEventListener(type, manualAbort, opts));
+      };
+
+      const unbindManualAbort = () => {
+        if (!manualListenersBound) return;
+        manualListenersBound = false;
+        MANUAL_EVENTS.forEach(([type, opts]) => manualTarget.removeEventListener(type, manualAbort, opts));
+      };
 
       function step(ts) {
         if (!lastTs) lastTs = ts;
         const dt = (ts - lastTs) / 1000; lastTs = ts;
 
         if (!paused && !ended) {
-          const maxY = root.scrollHeight - root.clientHeight;
-          const nextY = Math.min(root.scrollTop + SPEED * dt, maxY);
-          root.scrollTop = nextY;
+          const maxY = getMaxScrollTop();
+          const nextY = Math.min(getScrollTop() + SPEED * dt, maxY);
+          setScrollTop(nextY);
           if (nextY >= maxY - 0.5) { stop(true); return; }
         }
         rafId = requestAnimationFrame(step);
@@ -74,9 +139,13 @@
 
       function start(restart = false) {
         if (ended && !restart) return;
+        if (manualListenersBound) unbindManualAbort();
+        root = resolveScrollRoot();
+        manualTarget = isDocRoot(root) ? window : root;
         cancelAnimationFrame(rafId);
         lastTs = 0;
         paused = false;
+        bindManualAbort();
         rafId = requestAnimationFrame(step);
         hasStarted = true;
       }
@@ -85,6 +154,8 @@
         cancelAnimationFrame(rafId);
         rafId = null;
         lastTs = 0;
+        unbindManualAbort();
+        hasStarted = false;
         if (reachedBottom) ended = true;
       }
 
@@ -104,9 +175,14 @@
         if (btn) {
           btn.addEventListener('click', () => {
             ended = false; paused = false;
-            // resetea al tope
-            if (root.scrollTo) root.scrollTo({ top: 0, behavior: 'smooth' });
-            else root.scrollTop = 0;
+            const target = resolveScrollRoot();
+            if (isDocRoot(target)) {
+              window.scrollTo(0, 0);
+            } else if (typeof target.scrollTo === 'function') {
+              target.scrollTo({ top: 0 });
+            } else {
+              target.scrollTop = 0;
+            }
             setTimeout(() => start(true), 300);
           });
         }


### PR DESCRIPTION
## Summary
- ensure the guided tour scroller uses the proper scroll root and window APIs when the document scrolls the page
- update listener binding and restart logic so the tour resets instantly without the iOS bounce effect

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e46cc21c8083278fb39f1a6e9cbecd