### PR TITLE
Enable desktop view and improve responsive layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -327,14 +327,6 @@
 </head>
 
 <body>
-  <!-- Aviso para pantallas grandes -->
-  <div class="desktop-blocker" aria-hidden="true">
-    <div class="desktop-blocker__in">
-      <h2>Disponible solo en móvil 📱</h2>
-      <p>Abre esta invitación desde tu teléfono o reduce la ventana a menos de 768px de ancho.</p>
-    </div>
-  </div>
-
   <div class="container">
     <!-- Sección 1 -->
     <section class="hero decor-wrap">

--- a/style/style.unified.css
+++ b/style/style.unified.css
@@ -20,6 +20,7 @@
   --shadow-md: 0 8px 20px rgba(0, 0, 0, .12);
   --shadow: var(--shadow-md);
   --radius: 12px;
+  --page-padding: clamp(1rem, 4vw, 3rem);
 }
 
 /* Typography helpers */
@@ -71,6 +72,7 @@
   --card: #ffffff;
   --shadow: 0 10px 25px rgba(0, 0, 0, .08);
   --radius: 12px;
+  --page-padding: clamp(1rem, 4vw, 3rem);
 }
 
 body,
@@ -80,10 +82,26 @@ html {
   font-family: Arial, sans-serif;
   color: var(--text);
   background: var(--bg);
+  overflow-x: hidden;
 }
 
 .container {
+  width: 100%;
   margin: 0 auto;
+  padding: 0 var(--page-padding) clamp(3rem, 6vw, 4rem);
+}
+
+.container > section:not(.hero) {
+  max-width: 1100px;
+  margin-left: auto;
+  margin-right: auto;
+  padding: clamp(2.5rem, 5vw, 4rem) 0;
+}
+
+@media (min-width: 1200px) {
+  :root {
+    --page-padding: clamp(3rem, 8vw, 6rem);
+  }
 }
 
 img,
@@ -97,7 +115,7 @@ h1 {
 }
 
 .iniciales {
-  font-size: clamp(13rem, 5vw, 3rem);
+  font-size: clamp(3.5rem, 10vw, 12rem);
   font-family: 'ui-sans-serif';
 }
 
@@ -241,7 +259,7 @@ p {
 /* Responsivo: reducir o esconder en pantallas chicas para no tapar texto */
 @media (max-width: 640px) {
   .flower {
-    width: clamp(380px);
+    width: clamp(220px, 60vw, 380px);
     opacity: .85;
   }
 
@@ -254,48 +272,6 @@ p {
 @media (prefers-color-scheme: dark) {
   .flower {
     filter: brightness(.95) saturate(1.05);
-  }
-}
-
-/* --- Solo móvil: bloquear vista en pantallas >= 768px --- */
-
-/* Por defecto, el bloqueador NO se ve (móviles) */
-.desktop-blocker {
-  display: none;
-  position: fixed;
-  inset: 0;
-  background: #faf7f3;
-  /* un tono suave */
-  z-index: 9999;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  padding: 2rem;
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
-}
-
-.desktop-blocker__in {
-  max-width: 36rem;
-  margin: 0 auto;
-  line-height: 1.45;
-}
-
-/* A partir de 768px: ocultar todo el sitio y mostrar el bloqueador */
-@media (min-width: 768px) {
-
-  /* Oculta TODAS las secciones principales de tu página */
-  .container,
-  .section2,
-  .section4,
-  .section-gallery,
-  .section-dresscode,
-  .section3 {
-    display: none !important;
-  }
-
-  /* Muestra el aviso */
-  .desktop-blocker {
-    display: flex !important;
   }
 }
 
@@ -398,13 +374,6 @@ p {
   transform: scale(.98);
 }
 
-/* En desktop puedes ocultarlo (por si no bloqueas desktop) */
-@media (min-width:768px) {
-  .play-tour {
-    display: none;
-  }
-}
-
 /* Al iniciar el recorrido, ocultamos el botón suavemente */
 .tour-started .play-tour {
   opacity: 0;
@@ -454,12 +423,15 @@ p {
   position: relative;
   background: linear-gradient(rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0.25)), url('../img/IMAGEN1.jpeg') no-repeat center center/cover;
   width: 100%;
-  height: 100vh;
+  min-height: 100vh;
   display: flex;
   align-items: center;
   justify-content: center;
   color: white;
   text-align: center;
+  margin-left: calc(-1 * var(--page-padding));
+  margin-right: calc(-1 * var(--page-padding));
+  padding: clamp(2rem, 6vw, 4rem) var(--page-padding);
 }
 
 .hero h1 {
@@ -521,7 +493,7 @@ p {
 }
 
 .textnoscasamos {
-  font-size: clamp(4rem, 4vw, 2rem);
+  font-size: clamp(2.5rem, 6vw, 4.5rem);
   margin-bottom: 20px;
   color: #f5f5f5;
 }
@@ -535,12 +507,12 @@ p {
 }
 
 .number {
-  font-size: clamp(1.2rem, 4vw, 2rem);
+  font-size: clamp(1.4rem, 3.5vw, 2.4rem);
   font-weight: 700;
 }
 
 .label {
-  font-size: clamp(2rem, 2vw, .8rem);
+  font-size: clamp(.85rem, 2vw, 1.1rem);
   letter-spacing: 1px;
   font-family: 'Tangerine', cursive;
 
@@ -581,7 +553,7 @@ p {
 }
 
 .textnoscasamos2 {
-  font-size: clamp(2.4rem, 2.4vw, 1.35rem);
+  font-size: clamp(1.35rem, 3vw, 2.4rem);
   font-weight: 600;
   color: var(--black);
   letter-spacing: .02em;
@@ -591,7 +563,7 @@ p {
 }
 
 .textnoscasamos3 {
-  font-size: clamp(2.4rem, 2.4vw, 1.35rem);
+  font-size: clamp(1.35rem, 3vw, 2.4rem);
   font-weight: 600;
   color: var(--black);
   letter-spacing: .02em;
@@ -1247,7 +1219,7 @@ p {
 
 .dc-style {
   font-family: 'Italianno', cursive;
-  font-size: clamp(3rem, 5vw, 3rem);
+  font-size: clamp(2.4rem, 5vw, 3.4rem);
   font-weight: 700;
   color: #2e4d86;
   margin: 0 0 14px;


### PR DESCRIPTION
## Summary
- remove the desktop-only blocker so the invitation renders on large screens
- update spacing and typography clamps to scale smoothly across desktop and mobile
- add shared layout padding and hero adjustments to keep sections centered on wide viewports

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68e47548bfa883278759e64247ffd3eb