### PR TITLE
Improve hero section presentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,84 +80,112 @@
       background: var(--card);
       box-shadow: var(--shadow);
       overflow: hidden;
+      position: relative;
+      border-radius: var(--radius);
+    }
+
+    .card--hero {
+      display: grid;
+    }
+
+    .card--hero .card__media {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+
+    .card--hero .overlay {
+      z-index: 4;
     }
 
     .overlay {
       position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
+      inset: 0;
       display: flex;
       flex-direction: column;
       align-items: center;
       justify-content: center;
       text-align: center;
       color: white;
-      background: rgba(0, 0, 0, 0.35);
-      padding: 20px;
+      background: linear-gradient(180deg, rgba(0, 0, 0, 0.55) 0%, rgba(0, 0, 0, 0.35) 40%, rgba(0, 0, 0, 0.35) 100%);
+      padding: clamp(24px, 5vw, 48px);
+      gap: clamp(10px, 3vw, 18px);
     }
 
     blockquote {
       font-style: italic;
-      font-size: 1rem;
-      margin: 0 0 20px 0;
+      font-size: clamp(1rem, 3.2vw, 1.3rem);
+      margin: 0;
     }
 
     .quote-text {
       color: var(--bg);
-      font-size: 1.2rem;
+      font-size: clamp(1.1rem, 3.6vw, 1.6rem);
       font-family: 'Playfair Display', serif;
-
     }
 
     .quote-ref {
-      margin-top: 8px;
-      font-size: 0.9rem;
-      opacity: 0.8;
+      margin-top: 6px;
+      font-size: clamp(0.85rem, 2.4vw, 1rem);
+      opacity: 0.85;
     }
 
 
     .iniciales {
       font-weight: 700;
-      margin: 10px 0;
-      font-size: clamp(3.5rem, 10vw, 12rem);
+      margin: clamp(12px, 3vw, 18px) 0 clamp(6px, 2vw, 12px);
+      font-size: clamp(3.5rem, 10vw, 11rem);
+      letter-spacing: .1em;
       font-family: 'ui-sans-serif';
     }
 
 
     .textnoscasamos {
       font-family: 'Tangerine', cursive;
-      font-size: 2.5rem;
-      margin: 10px 0 20px;
+      font-size: clamp(2.1rem, 7vw, 3.1rem);
+      margin: 0;
+    }
+
+    .hero-names {
+      font-family: 'Great Vibes', cursive;
+      font-size: clamp(2.2rem, 8vw, 3.4rem);
+      color: var(--bg);
+      margin: 0;
+    }
+
+    .hero-details {
+      margin: 0;
+      color: rgba(255, 255, 255, 0.85);
+      font-size: clamp(1rem, 3vw, 1.2rem);
+      letter-spacing: .06em;
     }
 
 
     .countdown {
       display: flex;
-      gap: 10px;
+      gap: clamp(10px, 3vw, 18px);
       justify-content: center;
+      margin-top: clamp(14px, 4vw, 20px);
     }
 
     .box {
-      background: rgba(255, 255, 255, 0.2);
-      border-radius: 8px;
-      padding: 10px 14px;
+      background: rgba(255, 255, 255, 0.22);
+      border-radius: 12px;
+      padding: clamp(10px, 2.5vw, 16px) clamp(14px, 4vw, 20px);
       text-align: center;
-      min-width: 60px;
+      min-width: clamp(58px, 16vw, 88px);
+      backdrop-filter: blur(4px);
     }
 
     .number {
-      font-weight: bold;
-      font-size: clamp(1.4rem, 3.5vw, 2.4rem);
       font-weight: 700;
+      font-size: clamp(1.4rem, 4vw, 2.6rem);
     }
 
     .labelcount {
-      font-size: clamp(1rem, 2vw, 1.1rem);
+      font-size: clamp(0.95rem, 2.6vw, 1.2rem);
       letter-spacing: 1px;
       font-family: 'Tangerine', cursive;
-
     }
 
     .card__media {
@@ -246,8 +274,8 @@
 
     <!-- Sección 1: Portada -->
     <section class="section" id="s1">
-      <article class="card">
-              <img src="./img/Fondo_portada_arriba.png" alt="" class="flower flower--tl" aria-hidden="true" role="presentation">
+      <article class="card card--hero">
+        <img src="./img/Fondo_portada_arriba.png" alt="" class="flower flower--tl" aria-hidden="true" role="presentation">
 
         <img class="card__media sec1" alt="Pareja al atardecer"
           src="./img/IMAGEN1.jpeg?q=80&w=1600&auto=format&fit=crop" />
@@ -257,8 +285,10 @@
             <p class="quote-text">“Mi amado es mío, y yo soy suya.”</p>
             <footer class="quote-ref">— Cantares 2:16</footer>
           </blockquote>
-          <h1 class="iniciales" aria-label="Iniciales de los novios">S|A</h1>
+          <h1 class="iniciales" aria-label="Iniciales de los novios">S | A</h1>
           <h2 class="textnoscasamos">¡Nos casamos!</h2>
+          <p class="hero-names" aria-label="Sinai y Ariel">Sinai &amp; Ariel</p>
+          <p class="hero-details">28 de diciembre de 2025 · 4:00&nbsp;pm · Hueyapan de Ocampo</p>
           <div class="countdown" id="countdown">
             <div class="box">
               <div class="number" id="days">00</div>
@@ -524,7 +554,7 @@
 
 
     // Cuenta regresiva
-    const countdownDate = new Date('2025-11-15T17:00:00').getTime();
+    const countdownDate = new Date('2025-12-28T16:00:00').getTime();
     const countdown = setInterval(() => {
       const now = new Date().getTime();
       const distance = countdownDate - now;


### PR DESCRIPTION
## Summary
- adjust the hero card layout so the overlay stays within the section and add a gradient background for better legibility
- highlight the couple's names and event details in the opening section and restyle the countdown blocks
- align the countdown target date with the published ceremony information

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e4881f351483279c5f01a17554055f