### PR TITLE
Remove unused styles from invitation theme

### DIFF
--- a/style/style.unified.css
+++ b/style/style.unified.css
@@ -1,2086 +1,748 @@
-    /* ===== UNIFIED STYLESHEET (generated) ===== */
-
-
-    /* =========================================
-   Unified Theme Variables & Utilities
-   ========================================= */
-    :root {
-      /* Palette */
-      --bg: #f7f4ef;
-      --dc-bg: #f7f4ef;
-      --black: #000000;
-      --text: #3a3a3a;
-      --muted: #6b7280;
-      --brand: #8b5e3c;
-      /* primary accent */
-      --accent: #bfa37a;
-      /* lighter accent */
-      --card: #ffffff;
-      --shadow-sm: 0 4px 10px rgba(0, 0, 0, .08);
-      --shadow-md: 0 8px 20px rgba(0, 0, 0, .12);
-      --shadow: var(--shadow-md);
-      --radius: 12px;
-      --page-padding: clamp(1rem, 4vw, 3rem);
-    }
-
-    /* Typography helpers */
-    .font-italianno {
-      font-family: 'Italianno', cursive;
-    }
-
-    .font-beau {
-      font-family: 'Beau Rivage', cursive;
-    }
-
-    .font-great {
-      font-family: 'Great Vibes', cursive;
-    }
-
-    .font-tangerine {
-      font-family: 'Tangerine', cursive;
-    }
-
-    /* Generic entrance animation hooks (paired with IntersectionObserver) */
-    .animate-in {
-      opacity: 0;
-      transform: translateY(20px);
-      transition: opacity .6s ease, transform .6s ease;
-    }
-
-    .is-visible {
-      opacity: 1;
-      transform: none;
-    }
-
-
-    /* ===== BASE ===== */
-
-    /* ===== Base & Variables ===== */
-    * {
-      box-sizing: border-box;
-    }
-
-    :root {
-      --bg: #f7f4ef;
-      --dc-bg: #f7f4ef;
-      --black: #000000;
-      --text: #3a3a3a;
-      --muted: #6b7280;
-      --dorado: #ad8a1f;
-      --accent: #2c3e50;
-      --brand: #0037aa;
-      --card: #ffffff;
-      --shadow: 0 10px 25px rgba(0, 0, 0, .08);
-      --radius: 12px;
-      --page-padding: clamp(1rem, 4vw, 3rem);
-    }
-
-    body,
-    html {
-      margin: 0;
-      padding: 0;
-      font-family: Arial, sans-serif;
-      color: var(--text);
-      background: var(--bg);
-      overflow-x: hidden;
-    }
-
-    .container {
-      width: 100%;
-      margin: 0 auto;
-      padding: 0 var(--page-padding) clamp(3rem, 6vw, 4rem);
-    }
-
-    .container>section:not(.hero) {
-      max-width: 1100px;
-      margin-left: auto;
-      margin-right: auto;
-      padding: clamp(2.5rem, 5vw, 4rem) 0;
-    }
-
-    @media (min-width: 1200px) {
-      :root {
-        --page-padding: clamp(3rem, 8vw, 6rem);
-      }
-    }
-
-    img,
-    iframe {
-      display: block;
-    }
-
-    h1 {
-      margin: 0 0 10px;
-      letter-spacing: .03em;
-    }
-
-    .iniciales {
-      font-size: clamp(3.5rem, 10vw, 12rem);
-      font-family: 'ui-sans-serif';
-    }
-
-    p {
-      font-size: clamp(.9rem, 2.5vw, 1.1rem);
-      color: #f5f5f5;
-    }
-
-    .fade-transition {
-      background: linear-gradient(to bottom, rgba(0, 0, 0, .42), #fff);
-    }
-
-    /* Fuente caligráfica Italianno */
-    .font-italianno {
-      font-family: 'Italianno', cursive;
-    }
-
-    /* Fuente elegante Beau Rivage */
-    .font-beau {
-      font-family: 'Beau Rivage', cursive;
-    }
-
-    /* Fuente manuscrita Great Vibes */
-    .font-great {
-      font-family: 'Great Vibes', cursive;
-      font-size: 2.4rem;
-    }
-
-    /* Fuente ligera y caligráfica Tangerine */
-
-
-    .timeline-content {
-      position: relative;
-      background: #fff;
-      padding: 1.5rem;
-      border-radius: 12px;
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-      text-align: center;
-    }
-
-    /* Icono */
-    .timeline-icon {
-      width: 50px;
-      /* ajusta el tamaño */
-      height: 50px;
-      display: block;
-      margin: 0 auto 10px;
-      /* centra el ícono arriba del texto */
-      object-fit: contain;
-      transition: transform 0.3s ease;
-    }
-
-    /* Animación sutil al pasar el mouse */
-    .timeline-icon:hover {
-      transform: scale(1.1) rotate(-5deg);
-    }
-
-
-    /* --- Flores decorativas reutilizables --- */
-    .flower {
-      position: absolute;
-      animation: float 8s ease-in-out infinite;
-
-      /* escala responsiva */
-      height: auto;
-      z-index: 2;
-      /* por encima del fondo, debajo del contenido si usas z>=3 */
-      pointer-events: none;
-      /* no bloquea clics/scroll */
-      user-select: none;
-      opacity: 0.95;
-    }
-
-    /* Variantes rápidas de esquina/posición */
-    .flower--tl {
-      top: 0;
-      left: 0;
-    }
-
-    .flower--tr {
-      top: 72%;
-      left: -1%;
-      width: 20%;
-    }
-
-    .flower--bl {
-      left: 0;
-    }
-
-    .flower--br {
-      bottom: 0;
-      right: 0;
-      transform: translate(15%, 15%) rotate(-4deg);
-    }
-
-    /* Variantes de alineación relativa (para pegar junto a tarjetas) */
-    .flower--left {
-      left: -60px;
-      top: 50%;
-      transform: translateY(-50%) rotate(-8deg);
-    }
-
-    .flower--right {
-      right: -60px;
-      top: 50%;
-      transform: translateY(-50%) rotate(8deg);
-    }
-
-    .flower--top {
-      top: -60px;
-      left: 50%;
-      transform: translateX(-50%) rotate(-3deg);
-    }
-
-    .flower--bottom {
-      bottom: -60px;
-      left: 50%;
-      transform: translateX(-50%) rotate(3deg);
-    }
-
-    /* Contenedores que aceptan decoraciones con posicionamiento absoluto */
-    .decor-wrap {
-      position: relative;
-      /* clave para posicionar la flor dentro */
-      isolation: isolate;
-      /* evita mezclas raras de z-index con fondos */
-    }
-
-    /* Ajustes por sección (opcional) */
-    .hero .flower {
-      filter: drop-shadow(0 8px 16px rgba(0, 0, 0, .15));
-    }
-
-    .section2 .flower {
-      opacity: .9;
-    }
-
-    .section4 .flower {
-      opacity: .85;
-    }
-
-
-
-    .map-wrap {
-      position: relative;
-    }
-
-    .map-link {
-      display: block;
-      position: relative;
-      cursor: pointer;
-      text-decoration: none;
-    }
-
-    .map-thumb {
-      width: 100%;
-      display: block;
-      border-radius: 12px;
-    }
-
-    .map-cta {
-      position: absolute;
-      left: 12px;
-      right: 12px;
-      bottom: 12px;
-      display: inline-block;
-      padding: .6rem .9rem;
-      border-radius: 999px;
-      background: rgba(0, 0, 0, .55);
-      color: #fff;
-      font-weight: 600;
-      text-align: center;
-      backdrop-filter: blur(2px);
-    }
-
-    .map-link:active .map-cta,
-    .map-link:hover .map-cta {
-      background: rgba(0, 0, 0, .7);
-    }
-
-    /* Botón “Play / Iniciar recorrido” */
-    .play-tour {
-      --bg: #ffffffea;
-      --fg: #222;
-      --shadow: 0 10px 25px rgba(0, 0, 0, .12);
-      display: inline-flex;
-      align-items: center;
-      gap: .6rem;
-      padding: .9rem 1.1rem;
-      border: 0;
-      border-radius: 999px;
-      background: var(--bg);
-      color: var(--fg);
-      font-weight: 700;
-      letter-spacing: .2px;
-      box-shadow: var(--shadow);
-      cursor: pointer;
-      position: relative;
-      margin-top: 1.25rem;
-      z-index: 5;
-      transition: transform .18s ease, box-shadow .18s ease, opacity .25s ease;
-    }
-
-    .play-tour__icon {
-      display: inline-flex;
-    }
-
-    .play-tour__label {
-      font-size: 1rem;
-    }
-
-    .play-tour__hint {
-      font-size: .78rem;
-      font-weight: 600;
-      opacity: .75;
-      margin-left: .15rem;
-    }
-
-    /* Pulso suave para llamar atención */
-    .play-tour::after {
-      content: "";
-      position: absolute;
-      inset: -6px;
-      border-radius: 999px;
-      box-shadow: 0 0 0 0 rgba(255, 255, 255, .65);
-      animation: pt-pulse 1.6s ease-out infinite;
-    }
-
-    @keyframes pt-pulse {
-      0% {
-        box-shadow: 0 0 0 0 rgba(255, 255, 255, .55);
-      }
-
-      100% {
-        box-shadow: 0 0 0 22px rgba(255, 255, 255, 0);
-      }
-    }
-
-    .play-tour:active {
-      transform: scale(.98);
-    }
-
-    /* Al iniciar el recorrido, ocultamos el botón suavemente */
-    .tour-started .play-tour {
-      opacity: 0;
-      pointer-events: none;
-      transform: translateY(2px) scale(.99);
-    }
-
-    /* Ejemplo base */
-    @keyframes fade-up {
-      from {
-        opacity: 0;
-        transform: translateY(30px);
-      }
-
-      to {
-        opacity: 1;
-        transform: translateY(0);
-      }
-    }
-
-    .hero .content {
-      animation: fade-up 1s ease .3s both;
-    }
-
-    @keyframes float {
-
-      0%,
-      100% {
-        transform: translateY(0);
-      }
-
-      50% {
-        transform: translateY(-6px);
-      }
-    }
-
-
-
-
-    /* ===== HERO ===== */
-
-    /* ===== Sección 1 (Hero) ===== */
-    .hero {
-      position: relative;
-      background: linear-gradient(rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0.25)), url('../img/IMAGEN1.jpeg') no-repeat center center/cover;
-      width: 100%;
-      min-height: 100vh;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      color: white;
-      text-align: center;
-      margin-left: calc(-1 * var(--page-padding));
-      margin-right: calc(-1 * var(--page-padding));
-      padding: clamp(2rem, 6vw, 4rem) var(--page-padding);
-    }
-
-    .hero h1 {
-      font-weight: 700;
-      letter-spacing: .05em;
-    }
-
-    .overlay {
-      position: absolute;
-      inset: 0;
-      background: rgba(0, 0, 0, .4);
-    }
-
-    .section-quote {
-      display: flex;
-      justify-content: center;
-    }
-
-    .quote-card {
-      max-width: 600px;
-      padding: 15px;
-      border-radius: 12px;
-      font-family: 'Playfair Display', serif;
-    }
-
-    .quote-card blockquote {
-      margin: 0;
-      text-align: left;
-    }
-
-    .quote-text {
-      font-size: 2rem;
-      font-style: italic;
-      color: #ffffff;
-      margin-bottom: 10px;
-      line-height: 1.5;
-    }
-
-    .quote-ref {
-      font-size: 1rem;
-      color: #ffffff;
-      text-align: right;
-      display: block;
-    }
-
-    .content {
-      position: relative;
-      z-index: 2;
-      max-width: 90%;
-      padding: 20px;
-    }
-
-    .countdown {
-      padding-top: 10%;
-      display: flex;
-      justify-content: space-between;
-      gap: 10px;
-      flex-wrap: wrap;
-    }
-
-
-    .box {
-      flex: 1;
-      min-width: 70px;
-      background: rgba(255, 255, 255, .2);
-      padding: 10px;
-      border-radius: 8px;
-    }
-
-    .number {
-      font-size: clamp(1.4rem, 3.5vw, 2.4rem);
-      font-weight: 700;
-    }
-
-    .label {
-      font-size: clamp(.85rem, 2vw, 1.1rem);
-      letter-spacing: 1px;
-      font-family: 'Tangerine', cursive;
-
-    }
-
-
-    /* ===== DONDE & CUANDO ===== */
-
-    /* ===== Sección 2 (Dónde & Cuándo) ===== */
-    .section2 {
-      position: relative;
-      color: var(--text);
-      text-align: center;
-      overflow: hidden;
-    }
-
-    .section2 h2 {
-      color: var(--brand);
-      letter-spacing: .1em;
-      font-weight: 600;
-      font-size: 1.6rem;
-      margin: 24px 0 8px;
-    }
-
-    .section2 p {
-      color: var(--black);
-      font-family: 'Tangerine', cursive;
-
-    }
-
-
-    .section2 .flower-bg {
-      position: absolute;
-      left: 50%;
-      width: min(960px, 120%);
-      object-fit: contain;
-      pointer-events: none;
-      z-index: 0;
-      transform: translateX(-50%);
-    }
-
-    .section2 .flower-bg--top {
-      top: -6%;
-    }
-
-    .section2 .flower-bg--bottom {
-      bottom: -8%;
-    }
-
-    .section2>*:not(.flower-bg) {
-      position: relative;
-      z-index: 1;
-    }
-
-    .textnoscasamos2 {
-      font-size: clamp(1.35rem, 3vw, 2.4rem);
-      font-weight: 600;
-      color: var(--black);
-      letter-spacing: .02em;
-      background: #eeece9;
-      box-shadow: var(--shadow);
-
-    }
-
-    .textnoscasamos3 {
-      font-size: clamp(1.35rem, 3vw, 2.4rem);
-      font-weight: 600;
-      color: var(--black);
-      letter-spacing: .02em;
-      background: #eeece9;
-
-    }
-
-    /* Grid de padres */
-    .parents-block {
-      max-width: 1000px;
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: 20px;
-    }
-
-    .parents-col {
-      background: #f9f7f4;
-      border-radius: var(--radius);
-      box-shadow: var(--shadow);
-      padding: 18px 16px;
-    }
-
-    .parents-col--full {
-      grid-column: 1 / -1;
-    }
-
-    .parents-title {
-      font-size: 2rem;
-      font-weight: 700;
-      color: var(--brand);
-      letter-spacing: .08em;
-      margin: 0 0 8px;
-    }
-
-    .parents-list {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-      color: var(--black);
-      line-height: 1.6;
-      font-size: 1.05rem;
-    }
-
-    .novios-list {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-      color: var(--dorado);
-      line-height: 1.6;
-      font-size: 5.4rem;
-      align-items: center;
-    }
-
-    .textnoscasamos4 {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-      line-height: 1.6;
-      font-size: 4.4rem;
-      align-items: center;
-    }
-
-    .textnoscasamos4 p {
-
-      color: var(--brand);
-    }
-
-    .parents-list .amp {
-      font-weight: 700;
-      color: var(--brand);
-      font-size: 1.15rem;
-      margin: 2px 0;
-    }
-
-    .invite-line {
-      margin: 14px auto 10px;
-      color: var(--muted);
-      font-size: 1.8rem;
-      font-family: 'Tangerine', cursive;
-    }
-
-    /* Dónde y Cuándo */
-    .where-when {
-      color: var(--brand);
-      letter-spacing: .06em;
-      font-weight: 700;
-      font-size: clamp(1.2rem, 2.6vw, 1.5rem);
-      margin: 18px 0 16px;
-    }
-
-    /* Event + Map grid */
-    .event-grid {
-      max-width: 1000px;
-      margin: 0 auto;
-      display: grid;
-      grid-template-columns: 1fr 1.15fr;
-      gap: 22px;
-      align-items: stretch;
-    }
-
-    .event-card {
-      background: var(--card);
-      border: 1px solid #eadfd3;
-      border-radius: var(--radius);
-      box-shadow: var(--shadow);
-      padding: 16px;
-      display: grid;
-      grid-template-columns: auto 1fr;
-      gap: 14px;
-      text-align: left;
-    }
-
-    .event-date {
-      background: #f5efe9;
-      color: var(--brand);
-      border-radius: 12px;
-      width: 96px;
-      min-width: 96px;
-      padding: 10px 8px;
-      display: grid;
-      place-items: center;
-      line-height: 1;
-    }
-
-    .event-date .day {
-      font-size: 4rem;
-      font-weight: 700;
-      font-family: 'Great Vibes', cursive;
-
-    }
-
-    .event-date .month {
-      font-size: 2rem;
-      letter-spacing: .14em;
-      font-family: 'Great Vibes', cursive;
-
-    }
-
-    .event-date .year {
-      font-size: 2rem;
-      letter-spacing: .12em;
-      color: #8f806f;
-      font-family: 'Great Vibes', cursive;
-
-    }
-
-    .event-info .event-title {
-      font-weight: 800;
-      font-size: 1.5rem;
-      color: var(--brand);
-      letter-spacing: .06em;
-      margin: 2px 0 6px;
-    }
-
-    .event-info .event-time {
-      font-size: 2.5rem;
-      color: #5f5a54;
-      margin: 0 0 6px;
-      letter-spacing: .04em;
-      font-family: 'Tangerine', cursive;
-
-    }
-
-    .event-info {
-      display: grid;
-      place-items: center;
-      /* centra horizontal y vertical */
-      text-align: center;
-    }
-
-    .event-info .font-beau {
-      text-align: center;
-    }
-
-    .event-info .event-place {
-      font-size: 1.5rem;
-      color: var(--black);
-      line-height: 1.5;
-      margin: 0;
-    }
-
-    /* Mapa responsive */
-    .map-wrap {
-      border-radius: var(--radius);
-      overflow: hidden;
-      box-shadow: var(--shadow);
-      background: #eee;
-      aspect-ratio: 4 / 3;
-    }
-
-    .map-wrap iframe {
-      width: 100%;
-      height: 100%;
-      border: 0;
-    }
-
-    /* Hover sutil */
-    .event-card:hover {
-      transform: translateY(-1px);
-      transition: transform .2s ease;
-    }
-
-
-    /* ===== TIMELINE ===== */
-
-    /* ===== Sección 3 (Itinerario en línea de tiempo) ===== */
-    .section4 {
-      background: var(--dc-bg);
-      font-family: 'Tangerine', cursive;
-
-    }
-
-    .section4 h2 {
-      text-align: center;
-      font-size: 3.8rem;
-      color: var(--brand);
-      margin-bottom: 0px;
-      letter-spacing: .08em;
-    }
-
-    .timeline {
-      position: relative;
-      max-width: 800px;
-      margin: 0 auto;
-    }
-
-    .font-tangerine {
-      font-family: 'Tangerine', cursive;
-    }
-
-    @media (max-width: 640px) {
-      .flower2 {
-        width: 100%;
-        position: relative;
-
-      }
-    }
-
-    .timeline::after {
-      content: '';
-      position: absolute;
-      width: 3px;
-      background: var(--brand);
-      top: 0;
-      bottom: 0;
-      left: 50%;
-      margin-left: -1.5px;
-    }
-
-    .timeline-item {
-      padding: 20px 30px;
-      position: relative;
-      width: 50%;
-      opacity: 0;
-      animation: timelineSlideLeft .75s ease forwards;
-      animation-delay: calc(.18s + var(--delay, 0s));
-      will-change: transform, opacity;
-    }
-
-    .timeline-item::after {
-      content: '';
-      position: absolute;
-      width: 20px;
-      height: 20px;
-      right: -10px;
-      background: var(--brand);
-      border: 3px solid #fff;
-      top: 30px;
-      border-radius: 50%;
-      z-index: 1;
-    }
-
-    .timeline-item.left {
-      left: 0;
-    }
-
-    .timeline-item.right {
-      left: 50%;
-    }
-
-    .timeline-item.right::after {
-      left: -10px;
-    }
-
-    .timeline-item:nth-child(even) {
-      animation-name: timelineSlideRight;
-    }
-
-    .timeline-item:nth-child(1) {
-      --delay: 0s;
-    }
-
-    .timeline-item:nth-child(2) {
-      --delay: .12s;
-    }
-
-    .timeline-item:nth-child(3) {
-      --delay: .24s;
-    }
-
-    .timeline-item:nth-child(4) {
-      --delay: .36s;
-    }
-
-    .timeline-item:nth-child(5) {
-      --delay: .48s;
-    }
-
-    .timeline-item:nth-child(6) {
-      --delay: .6s;
-    }
-
-    .timeline-content {
-      padding: 20px;
-      background: #f8f8f8;
-      position: relative;
-      border-radius: var(--radius);
-      box-shadow: var(--shadow);
-    }
-
-    .timeline-content h3 {
-      margin-top: 0;
-      color: var(--brand);
-      font-size: 2.2rem
-    }
-
-    .timeline-content p {
-      margin: 6px 0 0;
-      color: var(--brand);
-      font-family: 'Tangerine', cursive;
-      font-size: 1.6rem;
-    }
-
-    @keyframes timelineSlideLeft {
-      from {
-        opacity: 0;
-        transform: translate3d(-28px, 24px, 0);
-      }
-
-      to {
-        opacity: 1;
-        transform: translate3d(0, 0, 0);
-      }
-    }
-
-    @keyframes timelineSlideRight {
-      from {
-        opacity: 0;
-        transform: translate3d(28px, 24px, 0);
-      }
-
-      to {
-        opacity: 1;
-        transform: translate3d(0, 0, 0);
-      }
-    }
-
-    @media (prefers-reduced-motion: reduce) {
-      .timeline-item {
-        animation: none !important;
-        opacity: 1;
-        transform: none !important;
-      }
-    }
-
-    /* ===== Timeline: animación alternada odd/even ===== */
-
-    /* Estado base (antes de entrar al viewport) */
-    .timeline .timeline-item.animate-in {
-      opacity: 0;
-      will-change: transform, opacity, filter;
-    }
-
-    /* Pares e impares: direcciones de entrada diferentes */
-    @keyframes tl-slide-left {
-      from {
-        opacity: 0;
-        transform: translateX(-28px) scale(.98);
-        filter: blur(2px);
-      }
-
-      to {
-        opacity: 1;
-        transform: translateX(0) scale(1);
-        filter: blur(0);
-      }
-    }
-
-    @keyframes tl-slide-right {
-      from {
-        opacity: 0;
-        transform: translateX(28px) scale(.98);
-        filter: blur(2px);
-      }
-
-      to {
-        opacity: 1;
-        transform: translateX(0) scale(1);
-        filter: blur(0);
-      }
-    }
-
-    /* Al hacerse visibles, arrancan sus animaciones */
-    .timeline .timeline-item.animate-in.is-visible:nth-child(odd) {
-      animation: tl-slide-left .7s var(--tl-delay, 0ms) cubic-bezier(.22, .61, .36, 1) both;
-    }
-
-    .timeline .timeline-item.animate-in.is-visible:nth-child(even) {
-      animation: tl-slide-right .7s var(--tl-delay, 0ms) cubic-bezier(.22, .61, .36, 1) both;
-    }
-
-    /* Pequeño “stagger” por posición (opcional) */
-    .timeline .timeline-item {
-      --tl-delay: 0ms;
-    }
-
-    .timeline .timeline-item:nth-child(2) {
-      --tl-delay: 90ms;
-    }
-
-    .timeline .timeline-item:nth-child(3) {
-      --tl-delay: 180ms;
-    }
-
-    .timeline .timeline-item:nth-child(4) {
-      --tl-delay: 270ms;
-    }
-
-    .timeline .timeline-item:nth-child(5) {
-      --tl-delay: 360ms;
-    }
-
-    .timeline .timeline-item:nth-child(6) {
-      --tl-delay: 450ms;
-    }
-
-    /* Accesibilidad: si el usuario prefiere menos movimiento, desactiva animaciones */
-    @media (prefers-reduced-motion: reduce) {
-
-      .timeline .timeline-item.animate-in,
-      .timeline .timeline-item.animate-in.is-visible {
-        animation: none !important;
-        opacity: 1 !important;
-        transform: none !important;
-        filter: none !important;
-      }
-    }
-
-
-    /* ===== GALLERY ===== */
-
-    /* ===== Sección Galería (aislada) ===== */
-    .section-gallery {
-      background: #fff;
-      padding: 5px 5px;
-    }
-
-    .section-gallery h2 {
-      text-align: center;
-      font-size: 3.8rem;
-      color: #8b5e3c;
-      margin-bottom: 22px;
-      letter-spacing: .08em;
-    }
-
-    .g-stack-wrap {
-      max-width: 420px;
-      margin: 0 auto;
-    }
-
-    .g-stack {
-      position: relative;
-      height: 560px;
-      user-select: none;
-      touch-action: pan-y;
-    }
-
-    .g-card {
-      position: absolute;
-      inset: 0;
-      margin: auto;
-      width: min(92vw, 420px);
-      height: 560px;
-      border-radius: 18px;
-      overflow: hidden;
-      box-shadow: 0 10px 25px rgba(0, 0, 0, .08);
-      background: #ddd;
-      transform-origin: 50% 100%;
-      transition: transform .25s ease, opacity .25s ease;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      pointer-events: none;
-    }
-
-    .g-card:first-child {
-      pointer-events: auto;
-    }
-
-    .g-card img {
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-      display: block;
-    }
-
-    .g-card:nth-child(1) {
-      transform: translateY(0) scale(1);
-      z-index: 5;
-    }
-
-    .g-card:nth-child(2) {
-      transform: translateY(10px) scale(.98);
-      z-index: 4;
-      opacity: .95;
-    }
-
-    .g-card:nth-child(3) {
-      transform: translateY(20px) scale(.96);
-      z-index: 3;
-      opacity: .9;
-    }
-
-    .g-card:nth-child(n+4) {
-      transform: translateY(30px) scale(.94);
-      z-index: 2;
-      opacity: .85;
-    }
-
-    .g-hint {
-      text-align: center;
-      color: #6b7280;
-      font-size: .9rem;
-      margin-top: 12px;
-    }
-
-    .g-card.g-left {
-      transform: translate(-120vw, -10vh) rotate(-18deg);
-      opacity: 0;
-    }
-
-    .g-card.g-right {
-      transform: translate(120vw, -10vh) rotate(18deg);
-      opacity: 0;
-    }
-
-    .g-empty {
-      text-align: center;
-      color: #6b7280;
-      margin-top: 14px;
-      display: none;
-    }
-
-    .g-actions {
-      display: flex;
-      justify-content: center;
-      margin-top: 14px;
-      gap: 8px;
-    }
-
-    .g-btn {
-      background: transparent;
-      border: 1px solid #d6c3af;
-      color: #8b5e3c;
-      padding: 10px 16px;
-      border-radius: 999px;
-      cursor: pointer;
-    }
-
-    .g-btn:hover {
-      background: #f7f2ec;
-    }
-
-    /* ===== DRESSCODE ===== */
-
-    .dc-x {
-      position: relative;
-      width: var(--dc-chip-size);
-      height: 0;
-      color: var(--dc-x);
-    }
-
-    .dc-swatch {
-      width: var(--dc-chip-size);
-      height: var(--dc-chip-size);
-      border-radius: 999px;
-      border: 2px solid rgba(0, 0, 0, .12);
-      box-shadow: 0 4px 12px rgba(0, 0, 0, .08) inset;
-      position: relative;
-    }
-
-    .dc-chip {
-      display: grid;
-      justify-items: center;
-      gap: 8px;
-    }
-
-    /* ===========================
-   Sección: Código de vestimenta
-   =========================== */
-    .section-dresscode {
-      --dc-bg: #f7f4ef;
-      --dc-text: #3a3a3a;
-      --dc-accent: #8b5e3c;
-      --dc-muted: #6b7280;
-      --dc-chip-size: 72px;
-      --dc-x: #b54646;
-      background: var(--dc-bg);
-      color: var(--dc-text);
-      padding: 56px 20px;
-    }
-
-    .section-dresscode .dc-in {
-      max-width: 980px;
-      margin: 0 auto;
-      text-align: center;
-
-    }
-
-    .mirror-x {
-      transform: scaleX(-1);
-      position: absolute;
-      /* escala responsiva */
-      height: auto;
-      z-index: 2;
-      /* por encima del fondo, debajo del contenido si usas z>=3 */
-      pointer-events: none;
-      /* no bloquea clics/scroll */
-      user-select: none;
-      opacity: 0.3;
-    }
-
-    @media (max-width: 640px) {
-      .flower3 {
-        position: absolute;
-        width: 24rem;
-        height: auto;
-        z-index: 2;
-        pointer-events: none;
-        user-select: none;
-        opacity: 0.5;
-      }
-    }
-
-
-    .dc-eyebrow {
-      font-family: 'Tangerine', cursive;
-      font-size: 3.8rem;
-      letter-spacing: .1em;
-      color: var(--dc-accent);
-      margin: 0 0 8px;
-    }
-
-    .dc-style {
-      font-family: 'Italianno', cursive;
-      font-size: clamp(2.4rem, 5vw, 3.4rem);
-      font-weight: 700;
-      color: #2e4d86;
-      margin: 0 0 14px;
-
-    }
-
-    .dc-note {
-      font-family: 'Tangerine', cursive;
-      color: var(--dc-accent);
-      font-size: 2rem;
-      letter-spacing: .04em;
-      margin: 0 0 22px;
-    }
-
-    .dc-grid {
-      display: grid;
-      grid-template-columns: repeat(4, minmax(0, 1fr));
-      gap: 16px;
-      justify-items: center;
-      align-items: start;
-      list-style: none;
-      padding: 0;
-      margin: 0 auto;
-      max-width: 680px;
-    }
-
-    @media (max-width: 640px) {
-      .dc-grid {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-      }
-    }
-
-
-
-
-
-
-
-
-
-    .dc-chip-label {
-      font-size: 2rem;
-      color: var(--dc-muted);
-      font-family: 'Tangerine', cursive;
-    }
-
-    .dc-white {
-      background: #f5f5f5;
-    }
-
-    .dc-olive {
-      background: #b8b89b;
-    }
-
-    .dc-beige {
-      background: #d6c7b9;
-    }
-
-    .dc-navy {
-      background: #1e2f53;
-    }
-
-
-
-
-
-
-
-    /* ===== RSVP ===== */
-
-    /* ===== Sección 6 (RSVP) ===== */
-    .section3 {
-      padding: 40px 16px 80px;
-    }
-
-    .card {
-      max-width: 720px;
-      margin: 0 auto;
-      background: var(--card);
-      box-shadow: var(--shadow);
-      overflow: hidden;
-    }
-
-    .card img.banner {
-      width: 100%;
-      height: 220px;
-      object-fit: cover;
-      display: block;
-    }
-
-    .card-body {
-      padding: 22px;
-
-    }
-
-    .card-title {
-      text-align: center;
-
-    }
-
-    .section10 {
-      text-align: center;
-      color: red;
-      font-size: 3rem;
-      margin: 8px 0 4px;
-      font-family: 'Tangerine', cursive;
-    }
-
-    .card-sub {
-      text-align: center;
-      color: var(--muted);
-      font-size: .9rem;
-      margin-bottom: 18px;
-    }
-
-    .form-group {
-      margin-bottom: 16px;
-    }
-
-    .label {
-      display: block;
-      margin: 0 0 6px;
-      color: var(--text);
-    }
-
-    .labelcount {
-      color: var(--dc-bg);
-
-
-    }
-
-    .input,
-    .select,
-    .textarea {
-      width: 100%;
-      border: 1px solid #dcdcdc;
-      border-radius: 8px;
-      padding: 12px 14px;
-      font-size: 1rem;
-      outline: none;
-      transition: box-shadow .2s, border-color .2s;
-      background: #fff;
-    }
-
-    .input:focus,
-    .select:focus,
-    .textarea:focus {
-      border-color: #c7b7a2;
-      box-shadow: 0 0 0 4px rgba(139, 94, 60, .12);
-    }
-
-    .textarea {
-      min-height: 110px;
-      resize: vertical;
-    }
-
-    .options {
-      display: grid;
-      gap: 8px;
-      margin-top: 6px;
-      color: var(--text);
-    }
-
-    .row {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-    }
-
-    .actions {
-      display: flex;
-      justify-content: center;
-      margin-top: 18px;
-    }
-
-    .btn {
-      background: var(--brand);
-      color: #fff;
-      border: none;
-      border-radius: 999px;
-      padding: 12px 22px;
-      font-size: 1rem;
-      cursor: pointer;
-      box-shadow: 0 6px 14px rgba(139, 94, 60, .25);
-    }
-
-    .btn:hover {
-      filter: brightness(.95);
-    }
-
-    .muted {
-      color: var(--muted);
-      font-size: .85rem;
-      text-align: center;
-      margin-top: 8px;
-    }
-
-    .dc-note {
-      font-family: 'Tangerine', cursive;
-      color: #3a3a3a;
-      font-size: 2rem;
-      font-weight: 400;
-      letter-spacing: .04em;
-      margin: 0 0 22px;
-    }
-
-    /* Solo resalta la palabra “Evitar” */
-    .dc-note .dc-highlight {
-      color: var(--dc-x);
-      /* usa el dorado principal del tema */
-    }
-
-    /* Centrado universal para .scroll-hint */
-    .scroll-hint {
-      /* diseño bonito que ya tenías mejorado */
-      position: relative;
-      display: inline-flex;
-      /* se mide como contenido */
-      flex-direction: column;
-      align-items: center;
-      gap: .35rem;
-      font-family: "Tangerine", cursive;
-      letter-spacing: 0.5px;
-      text-shadow: 0 0 6px rgba(255, 255, 255, 0.8);
-      animation: hintFade 3s ease-in-out infinite;
-      user-select: none;
-
-      /* === centrado clave === */
-      margin: 1.25rem auto 0;
-      /* auto en los lados centra en bloque */
-      text-align: center;
-      /* por si el padre usa text-align distinto */
-    }
-
-    /* Si .scroll-hint está dentro de un contenedor flex (p.ej. .timeline) */
-    .timeline>.scroll-hint,
-    .section2>.scroll-hint,
-    .section-gallery>.scroll-hint,
-    .section-dresscode>.scroll-hint,
-    .section3>.scroll-hint {
-      align-self: center;
-      /* céntralo en el eje transversal de ese flex */
-      width: 100%;
-      /* para que el margin:auto tenga efecto */
-      display: flex;
-      /* y vuelve a centrar su propio contenido */
-      justify-content: center;
-    }
-
-    /* Variante opcional: flotante solo en la portada (si la quieres sobrepuesta) */
-    .hero .scroll-hint--floating {
-      position: absolute;
-      left: 50%;
-      bottom: 1.25rem;
-      transform: translateX(-50%);
-      margin: 0;
-      /* no hace falta auto cuando es absolute */
-    }
-
-    /* Flecha animada debajo del texto (como antes) */
-    .scroll-hint::after {
-      content: "";
-      width: 14px;
-      height: 14px;
-      border-left: 2px solid currentColor;
-      border-bottom: 2px solid currentColor;
-      transform: rotate(-45deg);
-      margin-top: 2px;
-      animation: arrowBounce 1.6s ease-in-out infinite;
-      opacity: 0.9;
-    }
-
-    @keyframes hintFade {
-
-      0%,
-      100% {
-        opacity: 1;
-        text-shadow: 0 0 6px rgba(255, 255, 255, 0.8);
-        transform: translateY(0);
-      }
-
-      50% {
-        opacity: 0.6;
-        text-shadow: 0 0 12px rgba(255, 255, 255, 0.9);
-        transform: translateY(2px);
-      }
-    }
-
-    @keyframes arrowBounce {
-
-      0%,
-      100% {
-        transform: rotate(-45deg) translateY(0);
-        opacity: 0.8;
-      }
-
-      50% {
-        transform: rotate(-45deg) translateY(6px);
-        opacity: 0.3;
-      }
-    }
-
-    /* Ajuste responsive */
-    @media (max-width: 480px) {
-      .scroll-hint {
-        font-size: 2.9rem;
-        gap: .25rem;
-      }
-
-      .scroll-hint::after {
-        width: 12px;
-        height: 12px;
-      }
-    }
-
-    /* --------- Reset mínimo --------- */
-    *,
-    *::before,
-    *::after {
-      box-sizing: border-box;
-    }
-
-    html,
-    body {
-      margin: 0;
-      padding: 0;
-      height: 100%;
-    }
-
-    .card__media1 {
-      display: block;
-      max-width: 100%;
-      height: auto;
-    }
-
-    .card__media2 {
-      display: block;
-      max-width: 100%;
-      height: auto;
-    }
-
-    /* --------- Tipografía / Colores --------- */
-    :root {
-      --bg: #fffaf7;
-      --text: #2c2c2c;
-      --muted: #6b6b6b;
-      --brand: #b57a6a;
-      /* rosa tostado */
-      --brand-2: #d9c6be;
-      /* arena suave */
-      --card: #ffffff;
-      --shadow: 0 10px 24px rgba(0, 0, 0, .10);
-      --radius: 18px;
-    }
-
-    body {
-      font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, "Helvetica Neue", Arial, "Apple Color Emoji", "Segoe UI Emoji";
-      background: var(--bg);
-      color: var(--text);
-      line-height: 1.5;
-      -webkit-font-smoothing: antialiased;
-      -moz-osx-font-smoothing: grayscale;
-      scroll-behavior: smooth;
-      /* apoyo para scrollIntoView */
-    }
-
-    /* --------- Layout con scroll-snap (ideal móvil) --------- */
-    main {
-      scroll-snap-type: y mandatory;
-      overflow-y: auto;
-      height: 100dvh;
-      /* 100% de viewport dinámico en móvil */
-    }
-
-    section.section {
-      min-height: 45dvh;
-      display: grid;
-      place-items: center;
-      padding: 0;
-      scroll-snap-align: start;
-      scroll-snap-stop: always;
-      position: relative;
-    }
-
-    /* --------- Tarjetas --------- */
-    .card {
-      width: 98.8vw;
-      height: 100%;
-      /* ocupa todo el ancho */
-      background: var(--card);
-      box-shadow: var(--shadow);
-      overflow: hidden;
-    }
-
-    .overlay {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      flex-direction: column;
-      align-items: center;
-      text-align: center;
-      color: white;
-      background: rgba(0, 0, 0, 0.35);
-      padding: 20px;
-    }
-
-    blockquote {
-      font-style: italic;
-      font-size: 1rem;
-      margin: 0 0 20px 0;
-    }
-
-    .quote-text {
-      color: var(--bg);
-      font-size: 2.2rem;
-      font-family: 'Playfair Display', serif;
-      padding: 10% 0 0 0;
-
-    }
-
-    .quote-ref {
-      margin-top: 8px;
-      font-size: 0.9rem;
-      opacity: 0.8;
-    }
-
-
-    .iniciales {
-      font-weight: 700;
-      margin: 10px 0;
-      font-size: clamp(6.5rem, 10vw, 12rem);
-      font-family: 'ui-sans-serif';
-    }
-
-
-    .textnoscasamos {
-      font-family: 'Tangerine', cursive;
-      font-size: 5.5rem;
-      margin: 10px 0 20px;
-    }
-
-
-    .countdown {
-      display: flex;
-      gap: 10px;
-      justify-content: center;
-    }
-
-    .box {
-      background: rgba(255, 255, 255, 0.2);
-      border-radius: 8px;
-      padding: 10px 14px;
-      text-align: center;
-      min-width: 60px;
-    }
-
-    .number {
-      font-weight: bold;
-      font-size: clamp(1.4rem, 3.5vw, 2.4rem);
-      font-weight: 700;
-    }
-
-    .labelcount {
-      font-size: clamp(1rem, 2vw, 1.1rem);
-      letter-spacing: 1px;
-      font-family: 'Tangerine', cursive;
-
-    }
-
-    .card__media {
-      width: 100%;
-      width: 100%;
-      object-fit: cover;
-      object-fit: cover;
-    }
-
-
-    .card__body {
-      padding: clamp(16px, 3.5vw, 28px);
-    }
-
-    .family-header {
-      text-align: center;
-      padding: 20px 16px 0 16px;
-    }
-
-    .family-title {
-      font-size: clamp(2.05rem, 4vw, 2.8rem);
-      font-weight: 700;
-      color: var(--brand);
-      letter-spacing: .06em;
-      margin: 0 0 8px 0;
-    }
-
-    .eyebrow {
-      text-transform: uppercase;
-      letter-spacing: .12em;
-      font-size: .78rem;
-      color: var(--brand);
-      margin: 0 0 8px 0;
-      font-weight: 700;
-    }
-
-    h2 {
-      margin: 0 0 6px 0;
-      font-size: clamp(1.4rem, 4.5vw, 2rem);
-    }
-
-    p {
-      color: var(--muted);
-      margin: 8px 0 0 0;
-    }
-
-
-
-    /* --------- Indicador sutil --------- */
-    .hint {
-      position: fixed;
-      top: 12px;
-      right: 12px;
-      background: rgba(0, 0, 0, .55);
-      color: #fff;
-      padding: 6px 10px;
-      border-radius: 999px;
-      font-size: .8rem;
-      z-index: 40;
-      opacity: .0;
-      transform: translateY(-8px);
-      transition: opacity .4s ease, transform .4s ease;
-      user-select: none;
-    }
-
-    .hint.show {
-      opacity: 1;
-      transform: translateY(0);
-    }
-
-    /* El contenedor debe ser relativo para posicionar hijos absolutos */
-    .card.card--hero {
-      position: relative;
-    }
-
-    /* La foto de fondo principal queda en el nivel 1 */
-    .card--hero .card__media.sec1 {
-      position: relative;
-      z-index: 1;
-    }
-
-    /* La flor (primera imagen) va por encima de la foto */
-    .flower {
-      position: absolute;
-      z-index: 3;
-      /* > 1 para estar encima de .card__media */
-      pointer-events: none;
-      /* para no bloquear toques/clics */
-      display: block;
-    }
-
-    /* Ubícala en la esquina que quieras (top-left en este ejemplo) */
-    .flower--tl {
-      top: 0;
-      left: 0;
-    }
-
-    /* Ya tienes el overlay en 4, se mantiene encima de todo */
-    .card--hero .overlay {
-      z-index: 4;
-    }
-
-    /* ===== DONDE & CUANDO ===== */
-
-    /* ===== Sección 2 (Dónde & Cuándo) ===== */
-
-
-    .textnoscasamos2 {
-      font-size: clamp(1.35rem, 3vw, 2.4rem);
-      font-weight: 600;
-      color: var(--black);
-      letter-spacing: .02em;
-      background: #eeece9;
-      box-shadow: var(--shadow);
-
-    }
-
-    .textnoscasamos3 {
-      font-size: clamp(1.35rem, 3vw, 2.4rem);
-      font-weight: 600;
-      color: var(--black);
-      letter-spacing: .02em;
-      background: #eeece9;
-
-    }
-
-    /* Grid de padres */
-    .parents-block {
-      max-width: 1000px;
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: 20px;
-    }
-
-    .parents-col {
-      background: #f9f7f4;
-      border-radius: var(--radius);
-      box-shadow: var(--shadow);
-      padding: 18px 16px;
-    }
-
-    .parents-col--full {
-      grid-column: 1 / -1;
-    }
-
-    .parents-title {
-      font-size: 2rem;
-      font-weight: 700;
-      color: var(--brand);
-      letter-spacing: .08em;
-      margin: 0 0 8px;
-    }
-
-    .parents-list {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-      color: var(--black);
-      line-height: 1.6;
-      font-size: 1.05rem;
-    }
-
-    .novios-list {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-      color: var(--dorado);
-      line-height: 1.6;
-      font-size: 5.4rem;
-      align-items: center;
-    }
-
-    .textnoscasamos4 {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-      line-height: 1.6;
-      font-size: 4.4rem;
-      align-items: center;
-    }
-
-    .textnoscasamos4 p {
-
-      color: var(--brand);
-    }
-
-    .parents-list .amp {
-      font-weight: 700;
-      color: var(--brand);
-      font-size: 1.15rem;
-      margin: 2px 0;
-    }
-
-    .invite-line {
-      margin: 14px auto 10px;
-      color: var(--muted);
-      font-size: 1.8rem;
-      font-family: 'Tangerine', cursive;
-    }
-
-    /* Dónde y Cuándo */
-    .where-when {
-      color: var(--brand);
-      letter-spacing: .06em;
-      font-weight: 700;
-      font-size: clamp(1.2rem, 2.6vw, 1.5rem);
-      margin: 18px 0 16px;
-    }
-
-    /* Event + Map grid */
-    .event-grid {
-      max-width: 1000px;
-      margin: 0 auto;
-      display: grid;
-      grid-template-columns: 1fr 1.15fr;
-      gap: 22px;
-      align-items: stretch;
-    }
-
-    .event-card {
-      background: var(--card);
-      border: 1px solid #eadfd3;
-      border-radius: var(--radius);
-      box-shadow: var(--shadow);
-      padding: 16px;
-      display: grid;
-      grid-template-columns: auto 1fr;
-      gap: 14px;
-      text-align: left;
-    }
-
-    .event-date {
-      background: #f5efe9;
-      color: var(--brand);
-      border-radius: 12px;
-      width: 96px;
-      min-width: 96px;
-      padding: 10px 8px;
-      display: grid;
-      place-items: center;
-      line-height: 1;
-    }
-
-    .event-date .day {
-      font-size: 4rem;
-      font-weight: 700;
-      font-family: 'Great Vibes', cursive;
-
-    }
-
-    .event-date .month {
-      font-size: 2rem;
-      letter-spacing: .14em;
-      font-family: 'Great Vibes', cursive;
-
-    }
-
-    .event-date .year {
-      font-size: 2rem;
-      letter-spacing: .12em;
-      color: #8f806f;
-      font-family: 'Great Vibes', cursive;
-
-    }
-
-    .event-info .event-title {
-      font-weight: 800;
-      font-size: 1.5rem;
-      color: var(--brand);
-      letter-spacing: .06em;
-      margin: 2px 0 6px;
-    }
-
-    .event-info .event-time {
-      font-size: 2.5rem;
-      color: #5f5a54;
-      margin: 0 0 6px;
-      letter-spacing: .04em;
-      font-family: 'Tangerine', cursive;
-
-    }
-
-    .event-info {
-      display: grid;
-      place-items: center;
-      /* centra horizontal y vertical */
-      text-align: center;
-    }
-
-    .event-info .font-beau {
-      text-align: center;
-    }
-
-    .event-info .event-place {
-      font-size: 1.5rem;
-      color: var(--black);
-      line-height: 1.5;
-      margin: 0;
-    }
-
-    /* Mapa responsive */
-    .map-wrap {
-      border-radius: var(--radius);
-      overflow: hidden;
-      box-shadow: var(--shadow);
-      background: #eee;
-      aspect-ratio: 4 / 3;
-    }
-
-    .map-wrap iframe {
-      width: 100%;
-      height: 100%;
-      border: 0;
-    }
-
-    .section2 {
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      /* centra verticalmente */
-      align-items: center;
-      /* centra horizontalmente */
-      text-align: center;
-      /* centra el texto */
-      min-height: 100vh;
-      /* ocupa toda la pantalla */
-      padding: 2rem;
-      background-color: var(--bg, #fffaf7);
-    }
-
-    /* Para centrar correctamente los bloques internos */
-    .section2 .parents-block,
-    .section2 .event-grid {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      text-align: center;
-      width: 100%;
-    }
-
-    /* Si tus columnas de padres usan grid o flex, asegúrate de centrar también */
-    .parents-col {
-      text-align: center;
-      margin-bottom: 1.5rem;
-    }
-
-    /* Centrar mapa e imagen */
-    .map-wrap {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      text-align: center;
-    }
-
-    /* Opcional: ajusta el scroll hint */
-    .scroll-hint {
-      margin-top: 2rem;
-      text-align: center;
-    }
-
-
-    /* Hover sutil */
-    .event-card:hover {
-      transform: translateY(-1px);
-      transition: transform .2s ease;
-    }
-
-    /* Typography helpers */
-    .font-italianno {
-      font-family: 'Italianno', cursive;
-    }
-
-    .font-beau {
-      font-family: 'Beau Rivage', cursive;
-    }
-
-    .font-great {
-      font-family: 'Great Vibes', cursive;
-    }
-
-    .font-tangerine {
-      font-family: 'Tangerine', cursive;
-    }
-
-
-    .start-btn {
-      pointer-events: auto;
-      /* clickeable */
-      background-color: #b57a6a;
-      color: #fff;
-      font-weight: 700;
-      border: none;
-      border-radius: 999px;
-      padding: 14px 26px;
-      font-size: 1.1rem;
-      box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
-      transition: transform 0.2s ease, background 0.2s ease;
-    }
-
-    .start-btn:hover {
-      background-color: #a56a5e;
-      transform: scale(1.05);
-    }
+:root {
+  --bg: #fffaf7;
+  --text: #2c2c2c;
+  --muted: #6b6b6b;
+  --brand: #b57a6a;
+  --brand-dark: #5f5a54;
+  --card: #ffffff;
+  --shadow: 0 10px 24px rgba(0, 0, 0, 0.1);
+  --radius: 18px;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  scroll-behavior: smooth;
+}
+
+img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+main {
+  height: 100dvh;
+  overflow-y: auto;
+  scroll-snap-type: y mandatory;
+}
+
+.section {
+  min-height: 45dvh;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  position: relative;
+  scroll-snap-align: start;
+  scroll-snap-stop: always;
+}
+
+.card {
+  position: relative;
+  width: min(94vw, 960px);
+  background: var(--card);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+
+.card--hero {
+  min-height: clamp(520px, 100vh, 720px);
+  display: flex;
+  align-items: stretch;
+}
+
+.card__media {
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+}
+
+.card__media1 {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.card--hero .card__media1 {
+  flex: 1 1 auto;
+}
+
+.card__media2 {
+  width: 100%;
+  height: auto;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 1.25rem;
+  text-align: center;
+  padding: clamp(1.5rem, 5vw, 3rem);
+  color: #fff;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.55) 0%, rgba(0, 0, 0, 0.35) 100%);
+}
+
+blockquote {
+  margin: 0;
+}
+
+.quote-text {
+  font-family: "Playfair Display", serif;
+  font-size: clamp(1.6rem, 4vw, 2.4rem);
+  color: #fff;
+  margin: 0;
+}
+
+.quote-ref {
+  margin-top: 0.5rem;
+  font-size: 1rem;
+  opacity: 0.85;
+  color: #fff;
+}
+
+.iniciales {
+  font-family: "ui-sans-serif";
+  font-size: clamp(5rem, 10vw, 12rem);
+  margin: 0;
+  letter-spacing: 0.05em;
+}
+
+.textnoscasamos {
+  font-family: "Tangerine", cursive;
+  font-size: clamp(3.8rem, 8vw, 5.6rem);
+  margin: 0;
+}
+
+.countdown {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.box {
+  min-width: 70px;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: rgba(255, 255, 255, 0.18);
+  text-align: center;
+}
+
+.number {
+  font-weight: 700;
+  font-size: clamp(1.5rem, 4vw, 2.6rem);
+  color: #fff;
+}
+
+.labelcount {
+  font-family: "Tangerine", cursive;
+  font-size: clamp(1.1rem, 3vw, 1.4rem);
+  color: #fff;
+  letter-spacing: 1px;
+}
+
+.start-wrap {
+  display: flex;
+  justify-content: center;
+  margin-top: 0.75rem;
+}
+
+.start-btn {
+  pointer-events: auto;
+  background: var(--brand);
+  color: #fff;
+  font-weight: 700;
+  border: none;
+  border-radius: 999px;
+  padding: 0.9rem 2rem;
+  font-size: 1.05rem;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.start-btn:hover {
+  background: #a56a5e;
+  transform: scale(1.05);
+}
+
+.hint {
+  position: fixed;
+  top: 12px;
+  right: 12px;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  z-index: 40;
+  opacity: 0;
+  transform: translateY(-8px);
+  transition: opacity 0.4s ease, transform 0.4s ease;
+  user-select: none;
+}
+
+.hint.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.card__body,
+.card-body {
+  padding: clamp(1.2rem, 4vw, 2rem);
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
+  color: var(--brand);
+  margin: 0 0 0.5rem;
+  font-weight: 700;
+}
+
+.family-header {
+  text-align: center;
+  padding: clamp(1.5rem, 3vw, 2rem) clamp(1.2rem, 3vw, 2rem) 0;
+}
+
+.family-title {
+  font-size: clamp(2.1rem, 4vw, 3rem);
+  color: var(--brand);
+  margin: 0;
+}
+
+.family-divider {
+  width: 80px;
+  height: 3px;
+  background: rgba(0, 0, 0, 0.1);
+  border-radius: 999px;
+  margin: 1rem auto 0;
+}
+
+.parents-grid {
+  display: grid;
+  gap: clamp(1rem, 3vw, 1.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  padding: clamp(1.2rem, 4vw, 2rem);
+}
+
+.parents-col {
+  background: #f9f7f4;
+  border-radius: var(--radius);
+  padding: 1.2rem 1.5rem;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.05);
+  text-align: center;
+}
+
+.parents-title {
+  font-size: 2rem;
+  color: var(--brand);
+  margin: 0 0 0.5rem;
+}
+
+.parents-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  color: var(--text);
+  font-size: 1.1rem;
+  line-height: 1.6;
+}
+
+.parents-list .amp {
+  display: inline-block;
+  font-size: 1.3rem;
+  color: var(--brand);
+  margin: 0 0.25rem;
+}
+
+.couple-wrap {
+  text-align: center;
+  padding: 0 0 clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.couple-eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+}
+
+.couple-names {
+  margin: 0.5rem 0 0;
+  font-size: clamp(2.8rem, 6vw, 4rem);
+  color: var(--brand);
+}
+
+.invite-line {
+  margin: 0 auto;
+  max-width: 520px;
+  color: var(--muted);
+  text-align: center;
+  font-size: 1.1rem;
+}
+
+.invite-cta {
+  margin: 0.5rem 0 0;
+  font-size: clamp(2.4rem, 6vw, 3.4rem);
+  text-align: center;
+  color: var(--brand);
+}
+
+.card__media--top,
+.card__media--bottom {
+  width: 100%;
+}
+
+.section10 {
+  text-align: center;
+  color: var(--brand);
+  font-family: "Tangerine", cursive;
+  font-size: clamp(2.6rem, 6vw, 3.4rem);
+  margin: 0 0 1.5rem;
+}
+
+.actions {
+  display: flex;
+  justify-content: center;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.8rem;
+  border-radius: 999px;
+  background: var(--brand);
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.18);
+  transition: transform 0.2s ease, filter 0.2s ease;
+}
+
+.btn:hover {
+  filter: brightness(0.95);
+  transform: translateY(-1px);
+}
+
+.font-italianno {
+  font-family: "Italianno", cursive;
+}
+
+.font-beau {
+  font-family: "Beau Rivage", cursive;
+}
+
+.font-great {
+  font-family: "Great Vibes", cursive;
+}
+
+.font-tangerine {
+  font-family: "Tangerine", cursive;
+}
+
+/* Flowers & decorative elements */
+.flower {
+  position: absolute;
+  pointer-events: none;
+  user-select: none;
+  z-index: 3;
+}
+
+.flower--tl {
+  top: 0;
+  left: 0;
+}
+
+.flower--bl {
+  left: 0;
+  bottom: 0;
+}
+
+.flower2 {
+  position: absolute;
+  width: clamp(140px, 30vw, 220px);
+  bottom: -20px;
+  left: 0;
+  pointer-events: none;
+  opacity: 0.65;
+}
+
+.mirror-x {
+  position: absolute;
+  top: -40px;
+  right: -30px;
+  width: clamp(180px, 36vw, 260px);
+  transform: scaleX(-1);
+  opacity: 0.3;
+  pointer-events: none;
+}
+
+/* Timeline */
+.timeline {
+  position: relative;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: clamp(1.5rem, 4vw, 2.5rem) 0;
+}
+
+.timeline::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 3px;
+  transform: translateX(-50%);
+  background: var(--brand);
+}
+
+.timeline-item {
+  position: relative;
+  width: 50%;
+  padding: 1.5rem 2rem;
+  opacity: 0;
+  animation: timelineFade 0.8s ease forwards;
+}
+
+.timeline-item.left {
+  left: 0;
+}
+
+.timeline-item.right {
+  left: 50%;
+}
+
+.timeline-item::after {
+  content: "";
+  position: absolute;
+  top: 32px;
+  right: -10px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--brand);
+  border: 3px solid #fff;
+}
+
+.timeline-item.right::after {
+  left: -10px;
+  right: auto;
+}
+
+.timeline-content {
+  background: #f8f8f8;
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+  text-align: center;
+}
+
+.timeline-content h3 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.8rem, 4vw, 2.4rem);
+  color: var(--brand);
+}
+
+.timeline-content p {
+  margin: 0;
+  color: var(--brand-dark);
+  font-family: "Tangerine", cursive;
+  font-size: clamp(1.6rem, 5vw, 2.2rem);
+}
+
+.timeline-icon {
+  width: 50px;
+  height: 50px;
+  margin: 0 auto 0.75rem;
+  object-fit: contain;
+  transition: transform 0.3s ease;
+}
+
+.timeline-icon:hover {
+  transform: scale(1.08) rotate(-4deg);
+}
+
+@keyframes timelineFade {
+  from {
+    opacity: 0;
+    transform: translateY(28px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 768px) {
+  .timeline::after {
+    left: 24px;
+  }
+
+  .timeline-item,
+  .timeline-item.right,
+  .timeline-item.left {
+    width: 100%;
+    left: 0;
+    padding-left: 3rem;
+  }
+
+  .timeline-item::after {
+    left: 12px;
+    right: auto;
+  }
+}
+
+/* Gallery */
+.g-stack-wrap {
+  max-width: 420px;
+  margin: 0 auto;
+}
+
+.g-stack {
+  position: relative;
+  height: 560px;
+  user-select: none;
+  touch-action: pan-y;
+}
+
+.g-card {
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: min(92vw, 420px);
+  height: 560px;
+  border-radius: 18px;
+  overflow: hidden;
+  background: #ddd;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+  transform-origin: 50% 100%;
+  transition: transform 0.25s ease, opacity 0.25s ease;
+  pointer-events: none;
+}
+
+.g-card:first-child {
+  pointer-events: auto;
+}
+
+.g-card img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.g-card:nth-child(1) {
+  transform: translateY(0) scale(1);
+  z-index: 5;
+}
+
+.g-card:nth-child(2) {
+  transform: translateY(10px) scale(0.98);
+  z-index: 4;
+  opacity: 0.95;
+}
+
+.g-card:nth-child(3) {
+  transform: translateY(20px) scale(0.96);
+  z-index: 3;
+  opacity: 0.9;
+}
+
+.g-card:nth-child(n+4) {
+  transform: translateY(30px) scale(0.94);
+  z-index: 2;
+  opacity: 0.85;
+}
+
+.g-card.g-left {
+  transform: translate(-120vw, -10vh) rotate(-18deg);
+  opacity: 0;
+}
+
+.g-card.g-right {
+  transform: translate(120vw, -10vh) rotate(18deg);
+  opacity: 0;
+}
+
+.g-hint {
+  margin-top: 0.75rem;
+  font-size: 0.9rem;
+  text-align: center;
+  color: var(--muted);
+}
+
+.g-actions {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.g-btn {
+  padding: 0.6rem 1.25rem;
+  border-radius: 999px;
+  border: 1px solid #d6c3af;
+  background: transparent;
+  color: var(--brand);
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.g-btn:hover {
+  background: #f7f2ec;
+}
+
+.g-empty {
+  margin-top: 0.75rem;
+  text-align: center;
+  color: var(--muted);
+  display: none;
+}
+
+/* Dress code */
+.dc-in {
+  position: relative;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  text-align: center;
+}
+
+.dc-eyebrow {
+  font-size: clamp(1.2rem, 3vw, 1.5rem);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  margin: 0 0 0.75rem;
+}
+
+.dc-style {
+  margin: 0;
+  font-size: clamp(2.2rem, 6vw, 3rem);
+  color: var(--brand);
+}
+
+.dc-note {
+  margin: 1rem 0 1.5rem;
+  font-size: clamp(1.4rem, 5vw, 2.2rem);
+  color: var(--brand);
+  font-family: "Tangerine", cursive;
+}
+
+.dc-highlight {
+  color: #b54646;
+}
+
+.dc-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1.2rem;
+  list-style: none;
+  padding: 0;
+  margin: 0 auto;
+  max-width: 640px;
+}
+
+.dc-chip {
+  display: grid;
+  justify-items: center;
+  gap: 0.5rem;
+}
+
+.dc-swatch {
+  width: 72px;
+  height: 72px;
+  border-radius: 999px;
+  border: 2px solid rgba(0, 0, 0, 0.12);
+  position: relative;
+  display: grid;
+  place-items: center;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08) inset;
+}
+
+.dc-x {
+  color: #b54646;
+  font-size: 1.4rem;
+}
+
+.dc-chip-label {
+  font-size: 1.8rem;
+  color: var(--muted);
+  font-family: "Tangerine", cursive;
+}
+
+.dc-white {
+  background: #f5f5f5;
+}
+
+.dc-olive {
+  background: #b8b89b;
+}
+
+.dc-beige {
+  background: #d6c7b9;
+}
+
+.dc-navy {
+  background: #1e2f53;
+}
+
+/* Utilities */
+.number,
+.start-btn,
+.btn,
+.dc-style,
+.dc-note,
+.invite-cta,
+.textnoscasamos {
+  -webkit-font-smoothing: antialiased;
+}
+
+@media (max-width: 600px) {
+  .card {
+    width: 96vw;
+  }
+
+  .overlay {
+    padding: 2.5rem 1.5rem;
+  }
+
+  .mirror-x {
+    top: -20px;
+    right: -10px;
+  }
+
+  .g-stack {
+    height: 440px;
+  }
+
+  .g-card {
+    height: 440px;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the autogenerated stylesheet with a hand-curated version containing only the selectors used by the invitation page
- retain styling for the hero, family, timeline, gallery, dress code, and CTA sections while simplifying variables and layout defaults

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e73bd09bb88327b68866980371f7c3