### PR TITLE
Center itinerary and moments headings

### DIFF
--- a/style/style.unified.css
+++ b/style/style.unified.css
@@ -367,15 +367,12 @@ blockquote {
   font-family: "Tangerine", cursive;
 }
 
-.section4 {
-  font-family: "Tangerine", cursive;
-  font-size: clamp(2.6rem, 5vw, 2.2rem);
-
-}
+.section4,
 .section5 {
   font-family: "Tangerine", cursive;
   font-size: clamp(2.6rem, 5vw, 2.2rem);
-
+  text-align: center;
+  margin: 0;
 }
 /* Flowers & decorative elements */
 .flower {


### PR DESCRIPTION
## Summary
- center-align the "Itinerario" and "Momentos" section headings for consistent presentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e74bfcaf2c83279a1ef37209b245f7