### PR TITLE
Add music play control and on-page console log viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,6 +99,9 @@
   <main id="root">
     <!-- Audio único -->
     <audio id="bgMusic" src="./mp3/musica.mp3" preload="auto" loop playsinline aria-hidden="true"></audio>
+    <button type="button" id="playMusicBtn" class="audio-btn" aria-controls="bgMusic">
+      ▶ Reproducir música
+    </button>
 
     <!-- ==================== Sección 1: Portada ==================== -->
     <section class="section" id="s1">
@@ -366,20 +369,67 @@
   </main>
 
   <!-- ======= Scripts finales: audio + countdown ======= -->
+  <div id="consoleOutput" class="console-output" aria-live="polite" aria-label="Salida de la consola"></div>
+
   <script>
+    (function setupConsoleMirror() {
+      const output = document.getElementById('consoleOutput');
+      if (!output) return;
+
+      const serialize = (value) => {
+        if (typeof value === 'string') return value;
+        try {
+          return JSON.stringify(value);
+        } catch (error) {
+          return String(value);
+        }
+      };
+
+      ['log', 'warn', 'error', 'info'].forEach((type) => {
+        const original = console[type];
+        console[type] = function patchedConsole(...args) {
+          if (typeof original === 'function') {
+            original.apply(console, args);
+          }
+
+          const entry = document.createElement('div');
+          entry.className = `console-line console-${type}`;
+          entry.textContent = args.map(serialize).join(' ');
+          output.appendChild(entry);
+          output.scrollTop = output.scrollHeight;
+        };
+      });
+    })();
+
     (function () {
       // Reproducir audio al primer gesto (móvil/desktop)
-      function unlockAndPlay() {
-        const audio = document.getElementById('bgMusic');
+      const audio = document.getElementById('bgMusic');
+      const playBtn = document.getElementById('playMusicBtn');
+
+      const playMusic = () => {
         if (!audio) return;
         audio.muted = false;   // por si inicia silenciado en algunos navegadores
         audio.volume = 0.7;    // ajusta a gusto
-        audio.play().catch(console.warn);
+        const attempt = audio.play();
+        if (attempt?.catch) attempt.catch(console.warn);
+      };
+
+      function unlockAndPlay() {
+        playMusic();
 
         // Eliminar listeners (solo una vez)
         window.removeEventListener('pointerdown', unlockAndPlay);
         window.removeEventListener('click', unlockAndPlay);
         window.removeEventListener('touchend', unlockAndPlay);
+      }
+
+      if (playBtn) {
+        playBtn.addEventListener('click', () => {
+          playMusic();
+          playBtn.classList.add('is-playing');
+          playBtn.setAttribute('aria-pressed', 'true');
+          playBtn.textContent = '🔊 Música reproduciéndose';
+        });
       }
       window.addEventListener('pointerdown', unlockAndPlay, { once: true });
       window.addEventListener('click', unlockAndPlay, { once: true });

--- a/style/style.unified.css
+++ b/style/style.unified.css
@@ -876,6 +876,65 @@ blockquote {
   display: none;
 }
 
+.audio-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  width: fit-content;
+  margin: 1rem auto 0;
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 999px;
+  background: var(--color-primary, #c9a46c);
+  color: #fff;
+  font-family: inherit;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.audio-btn:hover,
+.audio-btn:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
+  outline: none;
+}
+
+.audio-btn.is-playing {
+  background: var(--color-secondary, #6b9071);
+}
+
+.console-output {
+  margin: 2rem auto;
+  padding: 1rem;
+  max-width: min(720px, 90vw);
+  max-height: 220px;
+  overflow-y: auto;
+  background: rgba(0, 0, 0, 0.7);
+  color: #f5f5f5;
+  font-family: 'Roboto Mono', 'Fira Code', monospace;
+  font-size: 0.9rem;
+  border-radius: 12px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.2);
+}
+
+.console-line + .console-line {
+  margin-top: 0.35rem;
+}
+
+.console-line.console-warn {
+  color: #ffdd57;
+}
+
+.console-line.console-error {
+  color: #ff6b6b;
+}
+
+.console-line.console-info {
+  color: #6ec6ff;
+}
+
 /* Dress code */
 .dc-in {
   position: relative;


### PR DESCRIPTION
## Summary
- add a manual play button for the background music and reuse the existing unlock logic
- mirror console output into a dedicated section for on-page visibility
- style the new audio control and console log viewer

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e9f46ea6f88327a296c9a32424e42e