### PR TITLE
Add persistent floating music player

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,14 +100,17 @@
 
 <body>
   <main id="root">
-    <!-- Audio único -->
+    <div class="audio-player" role="region" aria-label="Reproductor de música">
+      <audio id="bgMusic" src="./mp3/musica.mp3" preload="auto" loop playsinline aria-hidden="true"></audio>
+      <button type="button" id="playMusicBtn" class="audio-player__control" aria-controls="bgMusic"
+        aria-pressed="false">
+        <span class="audio-player__icon" aria-hidden="true">▶</span>
+        <span class="audio-player__label">Reproducir</span>
+      </button>
+    </div>
 
     <!-- ==================== Sección 1: Portada ==================== -->
     <section class="section" id="s1">
-      <audio id="bgMusic" src="./mp3/musica.mp3" preload="auto" loop playsinline aria-hidden="true"></audio>
-      <button type="button" id="playMusicBtn" class="audio-btn" aria-controls="bgMusic">
-        ▶ Reproducir música
-      </button>
       <article class="card card--hero">
         <img src="./img/Fondo_portada_arriba.png" alt="" class="card__media2 flower flower--tl" aria-hidden="true"
           role="presentation">
@@ -416,6 +419,16 @@
       // Reproducir audio al primer gesto (móvil/desktop)
       const audio = document.getElementById('bgMusic');
       const playBtn = document.getElementById('playMusicBtn');
+      const icon = playBtn?.querySelector('.audio-player__icon');
+      const label = playBtn?.querySelector('.audio-player__label');
+
+      const setPlayingState = (isPlaying) => {
+        if (!playBtn) return;
+        playBtn.classList.toggle('is-playing', isPlaying);
+        playBtn.setAttribute('aria-pressed', String(isPlaying));
+        if (icon) icon.textContent = isPlaying ? '⏸' : '▶';
+        if (label) label.textContent = isPlaying ? 'Pausar' : 'Reproducir';
+      };
 
       const playMusic = () => {
         if (!audio) return;
@@ -423,10 +436,18 @@
         audio.volume = 0.7;    // ajusta a gusto
         const attempt = audio.play();
         if (attempt?.catch) attempt.catch(console.warn);
+        return attempt;
       };
 
+      if (audio) {
+        setPlayingState(!audio.paused);
+        audio.addEventListener('play', () => setPlayingState(true));
+        audio.addEventListener('pause', () => setPlayingState(false));
+      }
+
       function unlockAndPlay() {
-        playMusic();
+        const attempt = playMusic();
+        if (!attempt?.then) setPlayingState(true);
 
         // Eliminar listeners (solo una vez)
         window.removeEventListener('pointerdown', unlockAndPlay);
@@ -434,12 +455,14 @@
         window.removeEventListener('touchend', unlockAndPlay);
       }
 
-      if (playBtn) {
+      if (playBtn && audio) {
         playBtn.addEventListener('click', () => {
-          playMusic();
-          playBtn.classList.add('is-playing');
-          playBtn.setAttribute('aria-pressed', 'true');
-          playBtn.textContent = '🔊 Música reproduciéndose';
+          if (audio.paused) {
+            const attempt = playMusic();
+            if (!attempt?.then) setPlayingState(true);
+          } else {
+            audio.pause();
+          }
         });
       }
       window.addEventListener('pointerdown', unlockAndPlay, { once: true });

--- a/style/style.unified.css
+++ b/style/style.unified.css
@@ -32,6 +32,77 @@ body {
   scroll-behavior: smooth;
 }
 
+.audio-player {
+  position: fixed;
+  top: 1rem;
+  left: 1rem;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.55rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(181, 122, 106, 0.28);
+  box-shadow: 0 10px 30px rgba(31, 41, 55, 0.18);
+  backdrop-filter: blur(6px);
+}
+
+.audio-player__control {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin: 0;
+  padding: 0.35rem 0.75rem;
+  border: none;
+  border-radius: 999px;
+  background: rgba(181, 122, 106, 0.18);
+  color: var(--brand-dark);
+  font: 600 0.95rem/1.2 "Segoe UI", Roboto, sans-serif;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: background 0.25s ease, color 0.25s ease, transform 0.25s ease;
+}
+
+.audio-player__control:hover,
+.audio-player__control:focus-visible {
+  background: rgba(181, 122, 106, 0.3);
+  color: var(--blue-dark);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.audio-player__control.is-playing {
+  background: rgba(181, 122, 106, 0.85);
+  color: #fff;
+}
+
+.audio-player__icon {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.audio-player__label {
+  font-size: 0.95rem;
+}
+
+@media (max-width: 600px) {
+  .audio-player {
+    top: 0.65rem;
+    left: 0.65rem;
+    padding: 0.45rem 0.75rem;
+  }
+
+  .audio-player__control {
+    padding: 0.25rem 0.6rem;
+    font-size: 0.85rem;
+  }
+
+  .audio-player__icon {
+    font-size: 0.9rem;
+  }
+}
+
 img {
   display: block;
   max-width: 100%;
@@ -874,35 +945,6 @@ blockquote {
   text-align: center;
   color: var(--muted);
   display: none;
-}
-
-.audio-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  width: fit-content;
-  margin: 1rem auto 0;
-  padding: 0.75rem 1.5rem;
-  border: none;
-  border-radius: 999px;
-  background: var(--color-primary, #c9a46c);
-  color: #fff;
-  font-family: inherit;
-  font-size: 1rem;
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.audio-btn:hover,
-.audio-btn:focus {
-  transform: translateY(-1px);
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
-  outline: none;
-}
-
-.audio-btn.is-playing {
-  background: var(--color-secondary, #6b9071);
 }
 
 .console-output {


### PR DESCRIPTION
## Summary
- create a floating audio player anchored to the top-left corner of the app
- update the background music script to support play/pause toggling and UI state sync
- style the new player for desktop and mobile while removing the old button styles

## Testing
- Manual verification of the floating player in the browser

------
https://chatgpt.com/codex/tasks/task_e_68ead25a85c88327a1e4314436dbd8ff