### PR TITLE
Improve hero swipe cue and responsive layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,8 +144,8 @@
           </div>
 
           <div class="swipe-indicator" aria-hidden="true">
-            <span class="swipe-indicator__hand" aria-hidden="true">👇</span>
-            <span class="swipe-indicator__text">Desliza hacia abajo</span>
+            <span class="swipe-indicator__icon" aria-hidden="true"></span>
+            <span class="swipe-indicator__text">Desliza hacia arriba</span>
           </div>
         </div>
       </article>

--- a/style/style.unified.css
+++ b/style/style.unified.css
@@ -467,30 +467,54 @@ blockquote {
   bottom: clamp(1rem, 4vw, 2.5rem);
   left: 50%;
   transform: translateX(-50%);
-  display: flex;
-  flex-direction: column;
+  display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.75rem 1.25rem;
+  gap: 0.75rem;
+  padding: 0.85rem 1.4rem;
   border-radius: 999px;
-  background: rgba(17, 17, 17, 0.55);
-  backdrop-filter: blur(6px);
+  background: rgba(14, 14, 14, 0.58);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.32);
   color: #fff;
   font-size: 0.95rem;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
   transition: opacity 0.3s ease, transform 0.3s ease;
 }
 
-.swipe-indicator__hand {
-  font-size: clamp(2.25rem, 6vw, 3rem);
-  line-height: 1;
-  animation: swipeDown 1.8s infinite ease-out;
+.swipe-indicator__icon {
+  position: relative;
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.22), rgba(255, 255, 255, 0.08));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5), inset 0 -8px 16px rgba(0, 0, 0, 0.3);
+  overflow: hidden;
+}
+
+.swipe-indicator__icon::before {
+  content: "";
+  position: absolute;
+  inset: 4px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 35%, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0));
+  opacity: 0.75;
+}
+
+.swipe-indicator__icon::after {
+  content: "\2191";
+  font-size: 1.6rem;
+  color: #fff;
+  text-shadow: 0 8px 18px rgba(0, 0, 0, 0.4);
+  animation: swipeUp 1.8s ease-in-out infinite;
 }
 
 .swipe-indicator__text {
   font-weight: 600;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.12em;
 }
 
 .swipe-indicator--hidden {
@@ -499,20 +523,137 @@ blockquote {
   pointer-events: none;
 }
 
-@keyframes swipeDown {
+@keyframes swipeUp {
   0% {
-    transform: translateY(0);
-    opacity: 0.95;
+    transform: translateY(18px);
+    opacity: 0;
   }
-  50% {
-    transform: translateY(14px);
+
+  35% {
+    transform: translateY(6px);
     opacity: 1;
   }
+
+  70% {
+    transform: translateY(-6px);
+    opacity: 1;
+  }
+
   100% {
-    transform: translateY(28px);
-    opacity: 0.2;
+    transform: translateY(-18px);
+    opacity: 0;
   }
 }
+
+@media (max-width: 768px) {
+  .overlay {
+    padding: clamp(1.5rem, 6vw, 2.35rem);
+    gap: 1.15rem;
+  }
+
+  .countdown {
+    gap: 0.65rem;
+  }
+
+  .box {
+    min-width: 64px;
+    padding: 0.65rem 0.85rem;
+  }
+
+  .swipe-indicator {
+    gap: 0.65rem;
+    padding: 0.75rem 1.2rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .card {
+    width: min(96vw, 960px);
+  }
+
+  .card--hero {
+    min-height: clamp(520px, 100vh, 820px);
+  }
+
+  .overlay {
+    padding: clamp(1.4rem, 8vw, 1.8rem);
+    gap: 0.95rem;
+  }
+
+  .quote-text {
+    font-size: clamp(1.3rem, 7vw, 1.9rem);
+  }
+
+  .swipe-indicator {
+    width: calc(100% - 2.5rem);
+    max-width: 320px;
+    justify-content: center;
+  }
+
+  .swipe-indicator__icon {
+    width: 46px;
+    height: 46px;
+  }
+
+  .swipe-indicator__text {
+    letter-spacing: 0.08em;
+    font-size: 0.8rem;
+  }
+
+  .audio-player {
+    left: 50%;
+    transform: translateX(-50%);
+    width: calc(100% - 1.3rem);
+    max-width: 260px;
+  }
+
+  .audio-player__control {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+@media (max-width: 360px) {
+  .overlay {
+    padding: 1.25rem;
+    gap: 0.85rem;
+  }
+
+  .swipe-indicator {
+    padding: 0.7rem 1rem;
+  }
+
+  .swipe-indicator__text {
+    font-size: 0.75rem;
+  }
+}
+
+@media (min-width: 1200px) {
+  main {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .card {
+    border-radius: calc(var(--radius) + 4px);
+  }
+
+  .card--hero {
+    border-radius: calc(var(--radius) + 12px);
+  }
+
+  .overlay {
+    padding: clamp(3rem, 4vw, 4.5rem);
+    gap: 1.75rem;
+  }
+
+  .swipe-indicator {
+    gap: 1rem;
+    padding: 1rem 1.75rem;
+  }
+}
+
 
 .card__body,
 .card-body {


### PR DESCRIPTION
## Summary
- redesign the hero swipe hint with a glowing upward arrow and updated copy
- add responsive breakpoints that refine hero spacing, countdown sizing, audio controls, and the swipe cue across viewports
- tune large-screen styling to better center cards and expand spacing for wide displays

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68eadbc1d1c48327ad01c5db8d90ea58