### PR TITLE
Add desktop-only notice for mobile availability

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,6 +99,10 @@
 </head>
 
 <body>
+  <div class="desktop-warning" role="alert" aria-live="polite">
+    <p>Esta invitación está disponible únicamente en móvil.</p>
+  </div>
+
   <main id="root">
     <div class="audio-player" role="region" aria-label="Reproductor de música">
       <audio id="bgMusic" src="./mp3/musica.mp3" preload="auto" loop playsinline aria-hidden="true"></audio>

--- a/style/style.unified.css
+++ b/style/style.unified.css
@@ -103,6 +103,31 @@ body {
   }
 }
 
+.desktop-warning {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  background: var(--bg);
+  text-align: center;
+  font-size: clamp(1.25rem, 3vw, 2rem);
+  color: var(--brand-dark);
+  z-index: 2000;
+}
+
+@media (min-width: 768px) {
+  main,
+  .audio-player {
+    display: none;
+  }
+
+  .desktop-warning {
+    display: flex;
+  }
+}
+
 img {
   display: block;
   max-width: 100%;


### PR DESCRIPTION
## Summary
- add an accessibility-friendly notice indicating the invitation is only available on mobile devices
- hide the main content and audio controls on wider viewports while showing the notice full-screen

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f83a07472083279a1fba4c7c2b008c