### PR TITLE
Add hotel information section featuring Hotel Castillo graphic

### DIFF
--- a/img/tarja-informativa-hotel-castillo.svg
+++ b/img/tarja-informativa-hotel-castillo.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 810" role="img" aria-labelledby="title desc">
+  <title id="title">Tarja Informativa de Hotel Castillo</title>
+  <desc id="desc">Resumen de tarifas, políticas de reservación y datos de contacto del Hotel Castillo.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#082b63" />
+      <stop offset="100%" stop-color="#041b44" />
+    </linearGradient>
+    <style><![CDATA[
+      text { font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif; }
+      .title { font-size: 72px; font-weight: 700; fill: #f7c649; }
+      .subtitle { font-size: 42px; font-weight: 700; fill: #f7c649; }
+      .body { font-size: 28px; fill: #f3f6ff; }
+      .small { font-size: 24px; fill: #d9e2ff; }
+      .label { font-size: 30px; font-weight: 700; fill: #f3f6ff; }
+      .price { font-size: 30px; font-weight: 600; fill: #f7c649; }
+      .note { font-size: 24px; fill: #f8f9ff; }
+    ]]></style>
+    <clipPath id="photoClip">
+      <rect rx="24" ry="24" width="320" height="200" />
+    </clipPath>
+  </defs>
+
+  <rect fill="url(#bg)" width="1440" height="810" rx="36" ry="36" />
+
+  <g transform="translate(80 110)">
+    <text class="title">Tarja Informativa de Hotel Castillo</text>
+  </g>
+
+  <g transform="translate(80 200)">
+    <g transform="translate(0 0)">
+      <rect width="360" height="220" rx="28" ry="28" fill="#123a7b" stroke="#2159b5" stroke-width="4" />
+      <text x="40" y="70" class="label">KING SIZE</text>
+      <text x="40" y="118" class="price">$700 por día + $100 de</text>
+      <text x="40" y="152" class="price">depósito reembolsable</text>
+      <text x="40" y="196" class="small">Máx. 2 personas</text>
+    </g>
+
+    <g transform="translate(380 0)">
+      <rect width="360" height="220" rx="28" ry="28" fill="#123a7b" stroke="#2159b5" stroke-width="4" />
+      <text x="40" y="70" class="label">DOBLE</text>
+      <text x="40" y="118" class="price">$600 por día + $100 de</text>
+      <text x="40" y="152" class="price">depósito reembolsable</text>
+      <text x="40" y="196" class="small">Máx. 4 personas</text>
+    </g>
+
+    <g transform="translate(760 0)">
+      <rect width="360" height="220" rx="28" ry="28" fill="#123a7b" stroke="#2159b5" stroke-width="4" />
+      <text x="40" y="70" class="label">MATRIMONIAL</text>
+      <text x="40" y="118" class="price">$600 por día + $100 de</text>
+      <text x="40" y="152" class="price">depósito reembolsable</text>
+      <text x="40" y="196" class="small">Máx. 2 personas</text>
+    </g>
+  </g>
+
+  <g transform="translate(80 470)">
+    <text class="subtitle">Reservación</text>
+    <text class="body" x="0" y="70">Para apartar su habitación, se requiere un anticipo del 50% del costo total.</text>
+    <text class="body" x="0" y="110">Se recomienda realizar la reservación con anticipación, ya que durante el mes de diciembre</text>
+    <text class="body" x="0" y="150">el hotel suele encontrarse saturado.</text>
+  </g>
+
+  <g transform="translate(80 660)">
+    <text class="subtitle">Contacto</text>
+    <text class="body" x="0" y="64">Facebook: Hotel Castillo</text>
+    <text class="body" x="0" y="104">Teléfono: +52 1 294 170 1440</text>
+  </g>
+
+  <g transform="translate(1170 360)">
+    <rect width="200" height="300" rx="26" ry="26" fill="#123a7b" stroke="#2159b5" stroke-width="4" />
+    <text class="small" x="100" y="150" text-anchor="middle">Imágenes</text>
+    <text class="small" x="100" y="186" text-anchor="middle">referenciales</text>
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -366,7 +366,25 @@
       </div>
     </section>
 
-    <!-- ==================== Sección 7: RSVP ==================== -->
+    <!-- ==================== Sección 7: Información de Hotel ==================== -->
+    <section class="section" id="hotel-info" aria-labelledby="hotel-info-title">
+      <div class="card hotel-info">
+        <div class="card-body hotel-info__body">
+          <header class="hotel-info__header">
+            <h2 id="hotel-info-title" class="hotel-info__title">Alojamiento recomendado</h2>
+            <p class="hotel-info__subtitle">Tarja informativa del Hotel Castillo</p>
+          </header>
+          <figure class="hotel-info__figure">
+            <img src="./img/tarja-informativa-hotel-castillo.svg" width="720" height="405"
+              alt="Tarja informativa del Hotel Castillo con tarifas, requisitos de reservación y datos de contacto" />
+            <figcaption class="hotel-info__caption">Consulta las tarifas y políticas del Hotel Castillo para asegurar tu
+              estancia.</figcaption>
+          </figure>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Sección 8: RSVP ==================== -->
     <section class="section" id="s10">
       <div class="card">
         <div class="card-body">

--- a/style/style.unified.css
+++ b/style/style.unified.css
@@ -1293,6 +1293,58 @@ blockquote {
   background: #1e2f53;
 }
 
+/* Hotel info */
+.hotel-info {
+  background: #0b1f40;
+  border-radius: clamp(20px, 4vw, 28px);
+  overflow: hidden;
+  box-shadow: 0 20px 45px rgba(8, 31, 64, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.hotel-info__body {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  padding: clamp(1.75rem, 5vw, 3rem);
+  text-align: center;
+  color: #f2f5ff;
+}
+
+.hotel-info__header {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.hotel-info__title {
+  margin: 0;
+  font-size: clamp(2.1rem, 6vw, 3rem);
+  font-family: "Tangerine", cursive;
+  letter-spacing: 0.04em;
+}
+
+.hotel-info__subtitle {
+  margin: 0;
+  font-size: clamp(1rem, 3.5vw, 1.35rem);
+  color: rgba(242, 245, 255, 0.76);
+}
+
+.hotel-info__figure {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.hotel-info__figure img {
+  margin: 0 auto;
+  border-radius: clamp(16px, 3vw, 22px);
+  box-shadow: 0 18px 50px rgba(4, 19, 41, 0.45);
+}
+
+.hotel-info__caption {
+  margin: 0;
+  font-size: clamp(0.95rem, 3vw, 1.15rem);
+  color: rgba(242, 245, 255, 0.76);
+}
+
 /* Utilities */
 .number,
 .btn,


### PR DESCRIPTION
## Summary
- add a new section to highlight the Hotel Castillo informational card within the invitation
- style the hotel section to blend with the existing aesthetic and remain mobile friendly
- include an SVG illustration that recreates the provided hotel information graphic

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68fea431aba883278c08323b39f54131