### PR TITLE
Mostrar información de hotel mediante botón

### DIFF
--- a/index.html
+++ b/index.html
@@ -372,14 +372,16 @@
           <header class="hotel-info__header">
             <h2 id="hotel-info-title" class="hotel-info__title">Alojamiento recomendado</h2>
           </header>
-          <figure class="hotel-info__figure">
-            <img src="./img/hotel.jpeg" width="720" height="405"
-              alt="Tarja informativa del Hotel Castillo con tarifas, requisitos de reservación y datos de contacto"
-              id="hotelImage" class="hotel-info__image" role="button" tabindex="0"
-              aria-describedby="hotel-info-title hotel-info-caption" />
-            <figcaption class="hotel-info__caption" id="hotel-info-caption">Consulta las tarifas y políticas del Hotel Castillo para asegurar tu
-              estancia.</figcaption>
-          </figure>
+          <div class="hotel-info__content">
+            <p class="hotel-info__subtitle" id="hotel-info-description">Para aquellas personas que requieran hospedaje, ponemos a su disposición la
+              información del Hotel Castillo.</p>
+            <button type="button" id="hotelInfoButton" class="btn hotel-info__button" aria-controls="hotelImageModal"
+              aria-describedby="hotel-info-description hotel-info-note" aria-haspopup="dialog">
+              Ver detalles de hospedaje
+            </button>
+            <p class="hotel-info__note" id="hotel-info-note">El botón mostrará tarifas, requisitos de reservación y datos de contacto del
+              hotel recomendado.</p>
+          </div>
         </div>
       </div>
     </section>
@@ -394,7 +396,8 @@
         </div>
         <img src="./img/hotel.jpeg" alt="Tarja informativa del Hotel Castillo con tarifas, requisitos de reservación y datos de contacto"
           class="image-modal__img" />
-        <figcaption class="image-modal__caption">Toca fuera de la imagen o en el botón cerrar para volver.</figcaption>
+        <figcaption class="image-modal__caption">Información pensada para quienes requieran hospedaje. Toca fuera de la imagen o
+          en el botón cerrar para volver.</figcaption>
       </figure>
     </div>
 
@@ -433,7 +436,7 @@
         });
       }
 
-      const hotelImage = document.getElementById('hotelImage');
+      const hotelInfoButton = document.getElementById('hotelInfoButton');
       const hotelModal = document.getElementById('hotelImageModal');
       const dismissControls = hotelModal?.querySelectorAll('[data-dismiss-modal]');
       let lastFocusedElement = null;
@@ -464,13 +467,7 @@
         }
       }
 
-      hotelImage?.addEventListener('click', openHotelModal);
-      hotelImage?.addEventListener('keydown', (event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault();
-          openHotelModal();
-        }
-      });
+      hotelInfoButton?.addEventListener('click', openHotelModal);
 
       dismissControls?.forEach((control) => {
         control.addEventListener('click', closeHotelModal);

--- a/style/style.unified.css
+++ b/style/style.unified.css
@@ -1328,27 +1328,17 @@ blockquote {
   color: rgba(242, 245, 255, 0.76);
 }
 
-.hotel-info__figure {
+.hotel-info__content {
   display: grid;
-  gap: 0.75rem;
+  gap: clamp(1rem, 3vw, 1.5rem);
 }
 
-.hotel-info__figure img {
-  margin: 0 auto;
-  border-radius: clamp(16px, 3vw, 22px);
-  box-shadow: 0 18px 50px rgba(4, 19, 41, 0.45);
+.hotel-info__button {
+  justify-self: center;
+  width: min(100%, 320px);
 }
 
-.hotel-info__image {
-  cursor: zoom-in;
-}
-
-.hotel-info__image:focus-visible {
-  outline: 3px solid rgba(242, 245, 255, 0.9);
-  outline-offset: 6px;
-}
-
-.hotel-info__caption {
+.hotel-info__note {
   margin: 0;
   font-size: clamp(0.95rem, 3vw, 1.15rem);
   color: rgba(242, 245, 255, 0.76);


### PR DESCRIPTION
## Summary
- reemplazar la imagen visible del hotel por un texto explicativo y un botón para quienes requieren hospedaje
- actualizar el modal existente para mantener el detalle del hotel accesible desde el botón
- ajustar los estilos para el nuevo contenedor y el botón del apartado de hospedaje

## Testing
- no se realizaron pruebas; no aplica


------
https://chatgpt.com/codex/tasks/task_e_68feb617bc34832795ba553b187077c4