### PR TITLE
Add multi-hotel carousel to lodging modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -374,31 +374,52 @@
           </header>
           <div class="hotel-info__content">
             <p class="hotel-info__subtitle" id="hotel-info-description">Para aquellas personas que requieran hospedaje, ponemos a su disposición la
-              información del Hotel Castillo.</p>
+              información de los hoteles recomendados.</p>
             <button type="button" id="hotelInfoButton" class="btn hotel-info__button" aria-controls="hotelImageModal"
               aria-describedby="hotel-info-description hotel-info-note" aria-haspopup="dialog">
               Ver detalles de hospedaje
             </button>
-            <p class="hotel-info__note" id="hotel-info-note">El botón mostrará tarifas, requisitos de reservación y datos de contacto del
-              hotel recomendado.</p>
+            <p class="hotel-info__note" id="hotel-info-note">El botón mostrará tarifas, requisitos de reservación y datos de contacto de los
+              hoteles recomendados.</p>
           </div>
         </div>
       </div>
     </section>
 
     <div class="image-modal" id="hotelImageModal" role="dialog"
-      aria-labelledby="hotelImageModalTitle" aria-hidden="true">
+      aria-labelledby="hotelImageModalTitle" aria-modal="true" aria-hidden="true">
       <div class="image-modal__backdrop" data-dismiss-modal></div>
-      <figure class="image-modal__dialog" role="group" aria-labelledby="hotelImageModalTitle">
+      <div class="image-modal__dialog" role="group" aria-labelledby="hotelImageModalTitle">
         <div class="image-modal__header">
           <h2 id="hotelImageModalTitle" class="image-modal__title">Alojamiento recomendado</h2>
           <button type="button" class="image-modal__close" aria-label="Cerrar" data-dismiss-modal>&times;</button>
         </div>
-        <img src="./img/hotel.jpeg" alt="Tarja informativa del Hotel Castillo con tarifas, requisitos de reservación y datos de contacto"
-          class="image-modal__img" />
-        <figcaption class="image-modal__caption">Información pensada para quienes requieran hospedaje. Toca fuera de la imagen o
-          en el botón cerrar para volver.</figcaption>
-      </figure>
+        <div class="image-modal__body">
+          <div class="image-modal__slides">
+            <figure class="image-modal__figure is-active" data-hotel-name="Hotel 1" aria-hidden="false">
+              <img src="./img/hotel1.jpeg"
+                alt="Información detallada del Hotel 1 con tarifas, requisitos de reservación y datos de contacto"
+                class="image-modal__img" />
+              <figcaption class="image-modal__caption">Detalles del Hotel 1 con tarifas, requisitos de reservación y contacto.</figcaption>
+            </figure>
+            <figure class="image-modal__figure" data-hotel-name="Hotel 2" aria-hidden="true">
+              <img src="./img/hotel1.png"
+                alt="Información detallada del Hotel 2 con tarifas, requisitos de reservación y datos de contacto"
+                class="image-modal__img" />
+              <figcaption class="image-modal__caption">Detalles del Hotel 2 con tarifas, requisitos de reservación y contacto.</figcaption>
+            </figure>
+          </div>
+          <div class="image-modal__controls">
+            <button type="button" class="image-modal__nav" data-carousel-dir="prev" aria-label="Ver hotel anterior">
+              ◀
+            </button>
+            <span class="image-modal__pagination" aria-live="polite">Hotel 1 (1 de 2)</span>
+            <button type="button" class="image-modal__nav" data-carousel-dir="next" aria-label="Ver hotel siguiente">
+              ▶
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
 
     <!-- ==================== Sección 8: RSVP ==================== -->
@@ -439,7 +460,39 @@
       const hotelInfoButton = document.getElementById('hotelInfoButton');
       const hotelModal = document.getElementById('hotelImageModal');
       const dismissControls = hotelModal?.querySelectorAll('[data-dismiss-modal]');
+      const hotelSlides = hotelModal ? Array.from(hotelModal.querySelectorAll('.image-modal__figure')) : [];
+      const hotelPagination = hotelModal?.querySelector('.image-modal__pagination');
+      const hotelNavButtons = hotelModal ? Array.from(hotelModal.querySelectorAll('[data-carousel-dir]')) : [];
+      let currentHotelSlide = 0;
+
       let lastFocusedElement = null;
+
+      const updateHotelSlide = (index) => {
+        if (!hotelSlides.length) return;
+        const totalSlides = hotelSlides.length;
+        currentHotelSlide = (index + totalSlides) % totalSlides;
+        hotelSlides.forEach((slide, slideIndex) => {
+          const isActive = slideIndex === currentHotelSlide;
+          slide.classList.toggle('is-active', isActive);
+          slide.setAttribute('aria-hidden', String(!isActive));
+        });
+        if (hotelPagination) {
+          const activeSlide = hotelSlides[currentHotelSlide];
+          const hotelName = activeSlide?.getAttribute('data-hotel-name');
+          hotelPagination.textContent = hotelName
+            ? `${hotelName} (${currentHotelSlide + 1} de ${totalSlides})`
+            : `Hotel ${currentHotelSlide + 1} de ${totalSlides}`;
+          hotelPagination.toggleAttribute('hidden', totalSlides <= 1);
+        }
+        hotelNavButtons.forEach((button) => {
+          button.toggleAttribute('hidden', totalSlides <= 1);
+        });
+      };
+
+      const changeHotelSlide = (step) => {
+        if (!hotelSlides.length) return;
+        updateHotelSlide(currentHotelSlide + step);
+      };
 
       const closeHotelModal = () => {
         if (!hotelModal) return;
@@ -455,6 +508,7 @@
         if (!hotelModal) return;
         lastFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
         hotelModal.setAttribute('aria-hidden', 'false');
+        updateHotelSlide(0);
         const closeBtn = hotelModal.querySelector('.image-modal__close');
         closeBtn?.focus({ preventScroll: true });
         document.addEventListener('keydown', handleModalKeyDown);
@@ -464,10 +518,31 @@
         if (event.key === 'Escape') {
           event.preventDefault();
           closeHotelModal();
+          return;
+        }
+        if (event.key === 'ArrowLeft') {
+          event.preventDefault();
+          changeHotelSlide(-1);
+          return;
+        }
+        if (event.key === 'ArrowRight') {
+          event.preventDefault();
+          changeHotelSlide(1);
         }
       }
 
       hotelInfoButton?.addEventListener('click', openHotelModal);
+
+      hotelNavButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          const direction = button.getAttribute('data-carousel-dir');
+          if (direction === 'next') {
+            changeHotelSlide(1);
+          } else if (direction === 'prev') {
+            changeHotelSlide(-1);
+          }
+        });
+      });
 
       dismissControls?.forEach((control) => {
         control.addEventListener('click', closeHotelModal);

--- a/style/style.unified.css
+++ b/style/style.unified.css
@@ -1410,8 +1410,69 @@ blockquote {
   height: auto;
 }
 
+.image-modal__body {
+  display: grid;
+  gap: clamp(1rem, 3vw, 1.5rem);
+  padding-bottom: clamp(0.75rem, 2.5vw, 1.25rem);
+}
+
+.image-modal__slides {
+  position: relative;
+}
+
+.image-modal__figure {
+  margin: 0;
+  display: none;
+}
+
+.image-modal__figure.is-active {
+  display: block;
+}
+
 .image-modal__caption {
   padding: clamp(0.75rem, 2.5vw, 1.25rem) clamp(1rem, 4vw, 2rem) clamp(1.25rem, 5vw, 2.25rem);
+  font-size: clamp(1rem, 3.2vw, 1.25rem);
+  color: rgba(4, 19, 41, 0.7);
+  text-align: center;
+}
+
+.image-modal__controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(0.75rem, 3vw, 1.5rem);
+  padding: 0 clamp(1rem, 4vw, 2rem);
+}
+
+.image-modal__nav {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: clamp(2.25rem, 10vw, 3rem);
+  height: clamp(2.25rem, 10vw, 3rem);
+  border-radius: 999px;
+  border: 1px solid rgba(63, 61, 86, 0.3);
+  background: rgba(63, 61, 86, 0.1);
+  color: #3f3d56;
+  font-size: clamp(1.3rem, 4vw, 1.6rem);
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.image-modal__nav:hover {
+  background: rgba(63, 61, 86, 0.18);
+}
+
+.image-modal__nav:active {
+  transform: scale(0.95);
+}
+
+.image-modal__nav:focus-visible {
+  outline: 2px solid #3f3d56;
+  outline-offset: 3px;
+}
+
+.image-modal__pagination {
   font-size: clamp(1rem, 3.2vw, 1.25rem);
   color: rgba(4, 19, 41, 0.7);
   text-align: center;


### PR DESCRIPTION
## Summary
- update the lodging copy to reference multiple recommended hotels
- convert the lodging modal into a two-slide carousel with keyboard and button navigation
- add styling for the modal body, slides, navigation controls, and pagination indicator

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68febbea5fe083279e71e8521c36c094