### PR TITLE
Resaltar fecha de confirmación en RSVP

### DIFF
--- a/index.html
+++ b/index.html
@@ -369,7 +369,8 @@
       <div class="card">
         <div class="card-body">
           <div class="card-title section10">Tu presencia es muy importante para nosotros, por lo que nos gustaría que
-            nos confirmaras antes del 2 de diciembre</div>
+            nos confirmaras antes del <span class="section10__highlight" aria-label="Fecha límite de confirmación">2 de
+              diciembre</span></div>
           <div class="actions">
             <a href="https://wa.me/5219211024671?text=%C2%A1Hola!%20Quiero%20confirmar%20mi%20asistencia%20a%20la%20boda.%20Mi%20nombre%20es%20[Tu%20Nombre]."
               target="_blank" rel="noopener" class="btn">

--- a/style/style.unified.css
+++ b/style/style.unified.css
@@ -860,6 +860,20 @@ blockquote {
   margin: 0 0 1.5rem;
 }
 
+.section10__highlight {
+  display: inline-block;
+  margin-left: 0.35rem;
+  padding: 0.15rem 0.6rem 0.2rem;
+  border-radius: 999px;
+  background: rgba(181, 122, 106, 0.2);
+  color: var(--brand-dark);
+  font-family: "Segoe UI", Roboto, sans-serif;
+  font-size: clamp(1rem, 3.2vw, 1.3rem);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .actions {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## Summary
- destacar la fecha límite de confirmación dentro de la sección RSVP con un nuevo estilo resaltado
- añadir estilos específicos para la etiqueta destacada para mejorar la legibilidad y el énfasis visual

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_6900350a2d148327a93b9e2712076ac0